### PR TITLE
Feature/localdatabasemanager/#22

### DIFF
--- a/RollingPaper/RollingPaper.xcodeproj/project.pbxproj
+++ b/RollingPaper/RollingPaper.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		D251BDC728ED29670094ECD9 /* TemplateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D251BDC628ED29670094ECD9 /* TemplateModel.swift */; };
 		D251BDC928ED2A310094ECD9 /* TemplateEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = D251BDC828ED2A310094ECD9 /* TemplateEnum.swift */; };
 		D251BDCB28ED32890094ECD9 /* UIColor+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D251BDCA28ED32890094ECD9 /* UIColor+Extensions.swift */; };
+		D251BDCF28ED54A40094ECD9 /* LocalDatabaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D251BDCE28ED54A40094ECD9 /* LocalDatabaseManager.swift */; };
+		D251BDD128ED54DD0094ECD9 /* PaperModelFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D251BDD028ED54DD0094ECD9 /* PaperModelFileManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -57,6 +59,8 @@
 		D251BDC628ED29670094ECD9 /* TemplateModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateModel.swift; sourceTree = "<group>"; };
 		D251BDC828ED2A310094ECD9 /* TemplateEnum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateEnum.swift; sourceTree = "<group>"; };
 		D251BDCA28ED32890094ECD9 /* UIColor+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extensions.swift"; sourceTree = "<group>"; };
+		D251BDCE28ED54A40094ECD9 /* LocalDatabaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDatabaseManager.swift; sourceTree = "<group>"; };
+		D251BDD028ED54DD0094ECD9 /* PaperModelFileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaperModelFileManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -162,6 +166,8 @@
 			children = (
 				D22E4ABF28EBF805001091DA /* FirebaseAuthManager.swift */,
 				D22E4AC128EBFD7B001091DA /* FirestoreManager.swift */,
+				D251BDCE28ED54A40094ECD9 /* LocalDatabaseManager.swift */,
+				D251BDD028ED54DD0094ECD9 /* PaperModelFileManager.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -321,6 +327,7 @@
 				D22E4AA628EBDC72001091DA /* MainViewController.swift in Sources */,
 				D22E4AC628EBFD9C001091DA /* SignUpViewController.swift in Sources */,
 				D251BDC528ED26EE0094ECD9 /* CardModel.swift in Sources */,
+				D251BDCF28ED54A40094ECD9 /* LocalDatabaseManager.swift in Sources */,
 				D22E4AC028EBF805001091DA /* FirebaseAuthManager.swift in Sources */,
 				D22E4ACB28EBFDEA001091DA /* SignUpViewModel.swift in Sources */,
 				D22E4AC428EBFD91001091DA /* SignInViewController.swift in Sources */,
@@ -330,6 +337,7 @@
 				D22E4AC228EBFD7B001091DA /* FirestoreManager.swift in Sources */,
 				D251BDCB28ED32890094ECD9 /* UIColor+Extensions.swift in Sources */,
 				D251BDBF28ED219D0094ECD9 /* PaperModel.swift in Sources */,
+				D251BDD128ED54DD0094ECD9 /* PaperModelFileManager.swift in Sources */,
 				D22E4AA228EBDC72001091DA /* AppDelegate.swift in Sources */,
 				D22E4AA428EBDC72001091DA /* SceneDelegate.swift in Sources */,
 				D251BDBD28ED206F0094ECD9 /* UserModel.swift in Sources */,

--- a/RollingPaper/RollingPaper/Managers/FirestoreManager.swift
+++ b/RollingPaper/RollingPaper/Managers/FirestoreManager.swift
@@ -8,7 +8,6 @@
 import Foundation
 import Combine
 
-
 final class FirestoreManager {
     
 }

--- a/RollingPaper/RollingPaper/Managers/LocalDatabaseManager.swift
+++ b/RollingPaper/RollingPaper/Managers/LocalDatabaseManager.swift
@@ -1,0 +1,13 @@
+//
+//  LocalDatabaseManager.swift
+//  RollingPaper
+//
+//  Created by Junyeong Park on 2022/10/05.
+//
+
+import Foundation
+import Combine
+
+protocol LocalDatabaseManager {
+    var papersSubject: PassthroughSubject<[PaperModel], Error> {get set}
+}

--- a/RollingPaper/RollingPaper/Managers/LocalDatabaseManager.swift
+++ b/RollingPaper/RollingPaper/Managers/LocalDatabaseManager.swift
@@ -10,4 +10,5 @@ import Combine
 
 protocol LocalDatabaseManager {
     var papersSubject: PassthroughSubject<[PaperModel], Error> {get set}
+    func setData(value: [PaperModel]) -> AnyPublisher<Bool, Never>
 }

--- a/RollingPaper/RollingPaper/Managers/PaperModelFileManager.swift
+++ b/RollingPaper/RollingPaper/Managers/PaperModelFileManager.swift
@@ -14,6 +14,7 @@ final class PaperModelFileManager: LocalDatabaseManager {
     private let folderName = "downloaded_papers"
     init() {
         createFolderIfNeeded()
+        loadPapers()
     }
     
     private func createFolderIfNeeded() {
@@ -35,5 +36,20 @@ final class PaperModelFileManager: LocalDatabaseManager {
             .urls(for: .documentDirectory, in: .userDomainMask)
             .first?
             .appendingPathComponent(folderName)
+    }
+    
+    private func loadPapers() {
+        guard
+            let url = getFolderPath(),
+            FileManager.default.fileExists(atPath: url.path) else {
+            return
+        }
+        do {
+            let data = try Data(contentsOf: url)
+            let papers = try JSONDecoder().decode([PaperModel].self, from: data)
+            self.papersSubject.send(papers)
+        } catch {
+            self.papersSubject.send(completion: .failure(error))
+        }
     }
 }

--- a/RollingPaper/RollingPaper/Managers/PaperModelFileManager.swift
+++ b/RollingPaper/RollingPaper/Managers/PaperModelFileManager.swift
@@ -53,17 +53,22 @@ final class PaperModelFileManager: LocalDatabaseManager {
         }
     }
     
-    private func setData(value: [PaperModel]) {
-        guard
-            let url = getFolderPath(),
-            FileManager.default.fileExists(atPath: url.path) else {
-            return
+    func setData(value: [PaperModel]) -> AnyPublisher<Bool, Never> {
+        return Future<Bool, Never> { [weak self] promise in
+            if
+                let url = self?.getFolderPath(),
+                FileManager.default.fileExists(atPath: url.path) {
+                do {
+                    let data = try JSONEncoder().encode(value)
+                    try data.write(to: url)
+                    promise(.success(true))
+                } catch {
+                    promise(.success(false))
+                }
+            } else {
+                promise(.success(false))
+            }
         }
-        do {
-            let data = try JSONEncoder().encode(value)
-            try data.write(to: url)
-        } catch {
-            print(error.localizedDescription)
-        }
+        .eraseToAnyPublisher()
     }
 }

--- a/RollingPaper/RollingPaper/Managers/PaperModelFileManager.swift
+++ b/RollingPaper/RollingPaper/Managers/PaperModelFileManager.swift
@@ -52,4 +52,18 @@ final class PaperModelFileManager: LocalDatabaseManager {
             self.papersSubject.send(completion: .failure(error))
         }
     }
+    
+    private func setData(value: [PaperModel]) {
+        guard
+            let url = getFolderPath(),
+            FileManager.default.fileExists(atPath: url.path) else {
+            return
+        }
+        do {
+            let data = try JSONEncoder().encode(value)
+            try data.write(to: url)
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
 }

--- a/RollingPaper/RollingPaper/Managers/PaperModelFileManager.swift
+++ b/RollingPaper/RollingPaper/Managers/PaperModelFileManager.swift
@@ -1,0 +1,39 @@
+//
+//  PaperModelFileManager.swift
+//  RollingPaper
+//
+//  Created by Junyeong Park on 2022/10/05.
+//
+
+import Foundation
+import Combine
+import UIKit
+
+final class PaperModelFileManager: LocalDatabaseManager {
+    var papersSubject: PassthroughSubject<[PaperModel], Error> = .init()
+    private let folderName = "downloaded_papers"
+    init() {
+        createFolderIfNeeded()
+    }
+    
+    private func createFolderIfNeeded() {
+        guard let url = getFolderPath() else { return }
+        if !FileManager.default.fileExists(atPath: url.path) {
+            do {
+                try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true, attributes: nil)
+                print("Created Folder")
+            } catch {
+                print("Error Created Folder")
+                print(error.localizedDescription)
+            }
+        }
+    }
+    
+    private func getFolderPath() -> URL? {
+        return FileManager
+            .default
+            .urls(for: .documentDirectory, in: .userDomainMask)
+            .first?
+            .appendingPathComponent(folderName)
+    }
+}


### PR DESCRIPTION
# Issue Number
🔒 Close #22 

## New features
* 로컬 데이터 베이스 매니저 프로토콜 구현
* (임시) 파일 매니저를 사용하는 페이퍼 매니저 클래스 구현
- 뷰 모델 사용 방법
(1). 로컬 데이터베이스 매니저 프로토콜을 입력받아 초기화(목적: 특정한 종류의 매니저 클래스가 아니라 프로토콜을 받아 이후 스위칭을 편하게 하기 위해서입니다)
(2). 뷰 모델 이니셜라이즈 단에서 곧바로 구독(바인딩) → 해당 로컬 데이터베이스 매니저 프로토콜의 `papersSubject`를 구독합니다
(3). 데이터서비스 매니저가 이니셜라이즈될 때 해당 `papersSubject`는 현재 유저 디렉토리 기록된 데이터를 모두 로드하기 때문에 데이터 흐름은 파일 데이터 로드 → 데이터 서비스의 퍼블리셔에 해당 데이터 존재 → 뷰 모델이 구독하고 있기 때문에 데이터 흐름으로 예상됩니다

- screenshot(optional)

## Review points

## Questions
로컬 데이터베이스는 Realm, Coredata 모두 배열 데이터 자체를 있는 그대로 저장하여 보존하는 것으로 알고 있습니다. 즉 [1, 2, 3, 4, 5]의 배열 중 3을 제거한 [1, 2, 4, 5]을 세팅하기 위해서는 있는 그대로의 [1, 2, 3, 4, 5]에서 3을 빼는 것이 아니라 [1, 2, 4, 5]를 다시 로컬 데이터베이스에 '덮어 씌우는' 방식을 취합니다. (적어도 파일 매니저 단에 있어서는 그렇습니다) 그렇기 때문에 로컬 데이터베이스 매니저의 CRUD는 모두 `setData`라는 함수를 통해 이루어진다고 생각했고, 뷰 모델 단에서 어떤 데이터를 삭제/수정/추가할지 결정한다고 생각했습니다. → 추후 로컬 데이터베이스의 페이퍼 데이터를 로드, 삭제하는 뷰 + 뷰 모델 담당자와 함께 이야기하면 좋을 것 같습니다.

## References

- write here 

## Checklist

- [x] Is the branch you are merging on correct?
- [x] Do you comply with coding conventions?
- [x] Are there any changes not related to PR?
- [x] Has my code been self-reviewed?
