### PR TITLE
Feature/localdatamockdatabasemanager/#40

### DIFF
--- a/RollingPaper/RollingPaper.xcodeproj/project.pbxproj
+++ b/RollingPaper/RollingPaper.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 56;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -37,6 +37,7 @@
 		D2B6308228EE871C008365CB /* Combine+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B6308128EE871C008365CB /* Combine+Extensions.swift */; };
 		D2B6308428EEE2A1008365CB /* UIView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B6308328EEE2A1008365CB /* UIView+Extensions.swift */; };
 		D2B6308628EF0BCB008365CB /* UIFont+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B6308528EF0BCB008365CB /* UIFont+Extensions.swift */; };
+		D2B6308A28F158E7008365CB /* LocalDatabaseMockManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B6308928F158E7008365CB /* LocalDatabaseMockManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -86,6 +87,7 @@
 		D2B6308128EE871C008365CB /* Combine+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Combine+Extensions.swift"; sourceTree = "<group>"; };
 		D2B6308328EEE2A1008365CB /* UIView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extensions.swift"; sourceTree = "<group>"; };
 		D2B6308528EF0BCB008365CB /* UIFont+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extensions.swift"; sourceTree = "<group>"; };
+		D2B6308928F158E7008365CB /* LocalDatabaseMockManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDatabaseMockManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -215,6 +217,7 @@
 				D22E4AC128EBFD7B001091DA /* FirestoreManager.swift */,
 				D251BDCE28ED54A40094ECD9 /* LocalDatabaseManager.swift */,
 				D251BDD028ED54DD0094ECD9 /* PaperModelFileManager.swift */,
+				D2B6308928F158E7008365CB /* LocalDatabaseMockManager.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -413,6 +416,7 @@
 				D22E4AD428EC52DB001091DA /* UIApplication+Extensions.swift in Sources */,
 				D22E4AA628EBDC72001091DA /* MainViewController.swift in Sources */,
 				BCF2481328ED5335008CD0F9 /* TemplateSelectViewModel.swift in Sources */,
+				D2B6308A28F158E7008365CB /* LocalDatabaseMockManager.swift in Sources */,
 				D22E4AC628EBFD9C001091DA /* SignUpViewController.swift in Sources */,
 				BCF2481128ED512A008CD0F9 /* TemplateSelectViewController.swift in Sources */,
 				D251BDC528ED26EE0094ECD9 /* CardModel.swift in Sources */,

--- a/RollingPaper/RollingPaper/Managers/LocalDatabaseMockManager.swift
+++ b/RollingPaper/RollingPaper/Managers/LocalDatabaseMockManager.swift
@@ -7,11 +7,36 @@
 
 import Foundation
 import Combine
+import UIKit
 
 final class LocalDatabaseMockManager: LocalDatabaseManager {
-    static var shared: LocalDatabaseManager
+    static let shared: LocalDatabaseManager = LocalDatabaseMockManager()
     
-    var papersSubject: CurrentValueSubject<[PaperModel], Never>
+    var papersSubject: CurrentValueSubject<[PaperModel], Never> = .init([])
+    
+    private init() {
+        // Set originally set data as default paper data
+        loadPapers()
+    }
+    
+    private func loadPapers() {
+        var papers = [PaperModel]()
+        let today = Date()
+        let tomorrow = Calendar.current.date(byAdding: .day, value: 1, to: Date())!
+        var paper1 = PaperModel(cards: [], date: Date(), endTime: tomorrow, title: "MockPaper1", templateString: TemplateEnum.halloween.rawValue)
+        var paper2 = PaperModel(cards: [], date: Date(), endTime: tomorrow, title: "MockPaper2", templateString: TemplateEnum.grid.rawValue)
+        if
+            let mockImage = UIImage(systemName: "person"),
+            let mockData = mockImage.jpegData(compressionQuality: 0.8) {
+            let card1 = CardModel(date: Date(), content: mockData)
+            let card2 = CardModel(date: Date(), content: mockData)
+            let card3 = CardModel(date: Date(), content: mockData)
+            let card4 = CardModel(date: Date(), content: mockData)
+            paper1.cards.append(contentsOf: [card1, card2])
+            paper2.cards.append(contentsOf: [card3, card4])
+            papers.append(contentsOf: [paper1, paper2])
+        }
+    }
     
     func addPaper(paper: PaperModel) {
     }

--- a/RollingPaper/RollingPaper/Managers/LocalDatabaseMockManager.swift
+++ b/RollingPaper/RollingPaper/Managers/LocalDatabaseMockManager.swift
@@ -36,25 +36,60 @@ final class LocalDatabaseMockManager: LocalDatabaseManager {
             paper2.cards.append(contentsOf: [card3, card4])
             papers.append(contentsOf: [paper1, paper2])
         }
+        papersSubject.send(papers)
     }
     
     func addPaper(paper: PaperModel) {
+        papersSubject.send(papersSubject.value + [paper])
     }
     
     func addCard(paperId: String, card: CardModel) {
+        var currentPapers = papersSubject.value
+        if let index = currentPapers.firstIndex(where: { $0.paperId == paperId }) {
+            var paper = currentPapers[index]
+            paper.cards.append(card)
+            currentPapers[index] = paper
+            papersSubject.send(currentPapers)
+        }
     }
     
     func removePaper(paper: PaperModel) {
+        var currentPapers = papersSubject.value
+        if let index = currentPapers.firstIndex(where: { $0.paperId == paper.paperId }) {
+            currentPapers.remove(at: index)
+            papersSubject.send(currentPapers)
+        }
     }
     
     func removeCard(paperId: String, card: CardModel) {
+        var currentPapers = papersSubject.value
+        if let index = currentPapers.firstIndex(where: { $0.paperId == paperId }) {
+            var paper = currentPapers[index]
+            if let cardIndex = paper.cards.firstIndex(where: { $0.cardId == card.cardId }) {
+                paper.cards.remove(at: cardIndex)
+                currentPapers[index] = paper
+                papersSubject.send(currentPapers)
+            }
+        }
     }
     
     func updatePaper(paper: PaperModel) {
+        var currentPapers = papersSubject.value
+        if let index = currentPapers.firstIndex(where: { $0.paperId == paper.paperId }) {
+            currentPapers[index] = paper
+            papersSubject.send(currentPapers)
+        }
     }
     
     func updateCard(paperId: String, card: CardModel) {
+        var currentPapers = papersSubject.value
+        if let index = currentPapers.firstIndex(where: { $0.paperId == paperId }) {
+            var paper = currentPapers[index]
+            if let cardIndex = paper.cards.firstIndex(where: { $0.cardId == card.cardId }) {
+                paper.cards[cardIndex] = card
+                currentPapers[index] = paper
+                papersSubject.send(currentPapers)
+            }
+        }
     }
 }
-
-

--- a/RollingPaper/RollingPaper/Managers/LocalDatabaseMockManager.swift
+++ b/RollingPaper/RollingPaper/Managers/LocalDatabaseMockManager.swift
@@ -23,8 +23,8 @@ final class LocalDatabaseMockManager: LocalDatabaseManager {
         var papers = [PaperModel]()
         let today = Date()
         let tomorrow = Calendar.current.date(byAdding: .day, value: 1, to: Date())!
-        var paper1 = PaperModel(cards: [], date: Date(), endTime: tomorrow, title: "MockPaper1", templateString: TemplateEnum.halloween.rawValue)
-        var paper2 = PaperModel(cards: [], date: Date(), endTime: tomorrow, title: "MockPaper2", templateString: TemplateEnum.grid.rawValue)
+        var paper1 = PaperModel(cards: [], date: today, endTime: tomorrow, title: "MockPaper1", templateString: TemplateEnum.halloween.rawValue)
+        var paper2 = PaperModel(cards: [], date: today, endTime: tomorrow, title: "MockPaper2", templateString: TemplateEnum.grid.rawValue)
         if
             let mockImage = UIImage(systemName: "person"),
             let mockData = mockImage.jpegData(compressionQuality: 0.8) {

--- a/RollingPaper/RollingPaper/Managers/LocalDatabaseMockManager.swift
+++ b/RollingPaper/RollingPaper/Managers/LocalDatabaseMockManager.swift
@@ -1,0 +1,35 @@
+//
+//  LocalDatabaseMockManager.swift
+//  RollingPaper
+//
+//  Created by Junyeong Park on 2022/10/08.
+//
+
+import Foundation
+import Combine
+
+final class LocalDatabaseMockManager: LocalDatabaseManager {
+    static var shared: LocalDatabaseManager
+    
+    var papersSubject: CurrentValueSubject<[PaperModel], Never>
+    
+    func addPaper(paper: PaperModel) {
+    }
+    
+    func addCard(paperId: String, card: CardModel) {
+    }
+    
+    func removePaper(paper: PaperModel) {
+    }
+    
+    func removeCard(paperId: String, card: CardModel) {
+    }
+    
+    func updatePaper(paper: PaperModel) {
+    }
+    
+    func updateCard(paperId: String, card: CardModel) {
+    }
+}
+
+


### PR DESCRIPTION
# Issue Number
🔒 Close #40 

## New features

* LocalDatabase Protocol을 준수하는 싱글턴 패턴의 목데이터 매니저를 구현했습니다
* 페이퍼/카드를 사용하는 뷰 모델에서 해당 클래스를 호출, `papersSubject`를 구독한 뒤 데이터 변경 사항에 대한 로직을 구현 + 뷰 컨트롤러 상의 데이터 변경 함수 요청이라는 인풋을 받고 데이터베이스 매니저 상의 CRUD 함수를 호출하기만 하면 됩니다

- write here
- screenshot(optional)

## Review points

- write here

## Questions

- write here

## References

- write here 

## Checklist

- [x] Is the branch you are merging on correct?
- [x] Do you comply with coding conventions?
- [x] Are there any changes not related to PR?
- [x] Has my code been self-reviewed?
