### PR TITLE
Feature/connect view/#47

### DIFF
--- a/RollingPaper/RollingPaper.xcodeproj/project.pbxproj
+++ b/RollingPaper/RollingPaper.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		BCF2481328ED5335008CD0F9 /* TemplateSelectViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCF2481228ED5335008CD0F9 /* TemplateSelectViewModel.swift */; };
 		BCF2481728EFC499008CD0F9 /* SetPaperViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCF2481628EFC499008CD0F9 /* SetPaperViewController.swift */; };
 		BCF2481928EFC4CF008CD0F9 /* SetPaperViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCF2481828EFC4CF008CD0F9 /* SetPaperViewModel.swift */; };
+		BCF2481B28F50CEC008CD0F9 /* UINavigationController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCF2481A28F50CEC008CD0F9 /* UINavigationController+Extensions.swift */; };
 		C5AB305628EC119300C2E016 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = C5AB305528EC119300C2E016 /* .swiftlint.yml */; };
 		C5AB30BC28ED655200C2E016 /* RollingPaperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5AB30BB28ED655200C2E016 /* RollingPaperTests.swift */; };
 		C5AB30C328ED6A4000C2E016 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = C5AB30C228ED6A4000C2E016 /* GoogleService-Info.plist */; };
@@ -63,6 +64,7 @@
 		BCF2481228ED5335008CD0F9 /* TemplateSelectViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateSelectViewModel.swift; sourceTree = "<group>"; };
 		BCF2481628EFC499008CD0F9 /* SetPaperViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetPaperViewController.swift; sourceTree = "<group>"; };
 		BCF2481828EFC4CF008CD0F9 /* SetPaperViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetPaperViewModel.swift; sourceTree = "<group>"; };
+		BCF2481A28F50CEC008CD0F9 /* UINavigationController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Extensions.swift"; sourceTree = "<group>"; };
 		C5AB305528EC119300C2E016 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		C5AB30B928ED655200C2E016 /* RollingPaperTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RollingPaperTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C5AB30BB28ED655200C2E016 /* RollingPaperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RollingPaperTests.swift; sourceTree = "<group>"; };
@@ -185,6 +187,7 @@
 				D2B6308128EE871C008365CB /* Combine+Extensions.swift */,
 				D2B6308328EEE2A1008365CB /* UIView+Extensions.swift */,
 				D2B6308528EF0BCB008365CB /* UIFont+Extensions.swift */,
+				BCF2481A28F50CEC008CD0F9 /* UINavigationController+Extensions.swift */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -453,6 +456,7 @@
 				D251BDBF28ED219D0094ECD9 /* PaperModel.swift in Sources */,
 				D251BDD128ED54DD0094ECD9 /* PaperModelFileManager.swift in Sources */,
 				BCF2481728EFC499008CD0F9 /* SetPaperViewController.swift in Sources */,
+				BCF2481B28F50CEC008CD0F9 /* UINavigationController+Extensions.swift in Sources */,
 				D22E4AA228EBDC72001091DA /* AppDelegate.swift in Sources */,
 				D22E4AA428EBDC72001091DA /* SceneDelegate.swift in Sources */,
 				BCF2481928EFC4CF008CD0F9 /* SetPaperViewModel.swift in Sources */,

--- a/RollingPaper/RollingPaper/Controllers/SetPaperViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/SetPaperViewController.swift
@@ -10,6 +10,7 @@ import SnapKit
 import Combine
 
 class SetPaperViewController: UIViewController {
+    private let paperTitleTextField = UITextField()
     private let viewModel = SetPaperViewModel()
     private let input: PassthroughSubject<SetPaperViewModel.Input, Never> = .init()
     private var cancellables = Set<AnyCancellable>()
@@ -96,6 +97,9 @@ class SetPaperViewController: UIViewController {
             make.top.equalTo(title2.snp.bottom).offset(15)
             make.left.equalTo(title2)
         })
+        
+        let gesture = UITapGestureRecognizer(target: self, action: #selector(backgroundTapped))
+        view.addGestureRecognizer(gesture)
     }
     
     // 제목 뷰 가져오기
@@ -116,40 +120,44 @@ class SetPaperViewController: UIViewController {
     
     // 텍스트필드 뷰 가져오기
     private func getTextField(placeHolder: String) -> UITextField {
-        let textField = UITextField()
         let border = UIView()
         
-        textField.addSubview(border)
-        textField.placeholder = placeHolder
+        paperTitleTextField.addSubview(border)
+        paperTitleTextField.placeholder = placeHolder
         
         // 제목 입력할때마다 입력한 글자 저장
-        textField
+        paperTitleTextField
             .controlPublisher(for: .editingChanged)
             .sink(receiveValue: { _ in
-                self.input.send(.setPaperTitle(title: textField.text ?? ""))
+                self.input.send(.setPaperTitle(title: self.paperTitleTextField.text ?? ""))
             })
             .store(in: &cancellables)
         
         // 엔터 누르면 포커스 해제하고 키보드 내리기
-        textField
+        paperTitleTextField
             .controlPublisher(for: .editingDidEndOnExit)
             .sink(receiveValue: { _ in
-                textField.resignFirstResponder()
+                self.paperTitleTextField.resignFirstResponder()
             })
             .store(in: &cancellables)
     
         border.backgroundColor = .black
         border.snp.makeConstraints({ make in
-            make.top.equalTo(textField.snp.bottom)
+            make.top.equalTo(paperTitleTextField.snp.bottom)
             make.left.right.equalToSuperview()
             make.height.equalTo(2)
         })
         
-        return textField
+        return paperTitleTextField
     }
     
     // 생성하기 버튼 눌렀을 때 동작
     @objc private func createBtnPressed(_ sender: UIBarButtonItem) {
         input.send(.endSettingPaper)
+    }
+    
+    // 배경 눌렀을 때 동작
+    @objc func backgroundTapped(_ sender: UITapGestureRecognizer) {
+        paperTitleTextField.resignFirstResponder()
     }
 }

--- a/RollingPaper/RollingPaper/Controllers/SetPaperViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/SetPaperViewController.swift
@@ -28,6 +28,7 @@ class SetPaperViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setMainView()
+        setNavigationBar()
         bind()
     }
     
@@ -40,11 +41,21 @@ class SetPaperViewController: UIViewController {
                 switch event {
                 case .createPaperSuccess(let paper):
                     self.paper = paper
+                    print("페이퍼 생성 성공")
+                    // TODO: 페이퍼 객체 넘겨주면서 네비게이션 연결
+                    // navigationController?.pushViewController(, animated: true)
                 case .createPaperFail:
                     self.paper = nil
+                    print("페이퍼 생성 실패")
                 }
             })
             .store(in: &cancellables)
+    }
+    
+    // 네비게이션 바 초기화
+    private func setNavigationBar() {
+        let createBtn = UIBarButtonItem(title: "생성하기", style: .plain, target: self, action: #selector(createBtnPressed))
+        navigationItem.rightBarButtonItem = createBtn
     }
     
     // 메인 뷰 초기화
@@ -111,10 +122,19 @@ class SetPaperViewController: UIViewController {
         textField.addSubview(border)
         textField.placeholder = placeHolder
         
+        // 제목 입력할때마다 입력한 글자 저장
+        textField
+            .controlPublisher(for: .editingChanged)
+            .sink(receiveValue: { _ in
+                self.input.send(.setPaperTitle(title: textField.text ?? ""))
+            })
+            .store(in: &cancellables)
+        
+        // 엔터 누르면 포커스 해제하고 키보드 내리기
         textField
             .controlPublisher(for: .editingDidEndOnExit)
             .sink(receiveValue: { _ in
-                self.input.send(.setPaperTitle(title: textField.text ?? ""))
+                textField.resignFirstResponder()
             })
             .store(in: &cancellables)
     
@@ -128,5 +148,8 @@ class SetPaperViewController: UIViewController {
         return textField
     }
     
-    // TODO: 네이게이션 바에 있는 생성하기 버튼을 눌렀을 때 input 값 설정 및 뷰 이동하기
+    // 생성하기 버튼 눌렀을 때 동작
+    @objc private func createBtnPressed(_ sender: UIBarButtonItem) {
+        input.send(.endSettingPaper)
+    }
 }

--- a/RollingPaper/RollingPaper/Controllers/SetPaperViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/SetPaperViewController.swift
@@ -35,7 +35,7 @@ class SetPaperViewController: UIViewController {
     private func bind() {
         let output = viewModel.transform(input: input.eraseToAnyPublisher())
         output
-            .sink { [weak self] event in
+            .sink(receiveValue: { [weak self] event in
                 guard let self = self else {return}
                 switch event {
                 case .createPaperSuccess(let paper):
@@ -43,7 +43,7 @@ class SetPaperViewController: UIViewController {
                 case .createPaperFail:
                     self.paper = nil
                 }
-            }
+            })
             .store(in: &cancellables)
     }
     
@@ -63,28 +63,28 @@ class SetPaperViewController: UIViewController {
         view.addSubview(title2)
         view.addSubview(subtitle2)
         
-        title1.snp.makeConstraints { make in
+        title1.snp.makeConstraints({ make in
             make.top.equalToSuperview().offset(76)
             make.left.equalToSuperview().offset(76)
-        }
-        subtitle1.snp.makeConstraints { make in
+        })
+        subtitle1.snp.makeConstraints({ make in
             make.top.equalTo(title1.snp.bottom).offset(15)
             make.left.equalTo(title1)
-        }
-        textField.snp.makeConstraints { make in
+        })
+        textField.snp.makeConstraints({ make in
             make.top.equalTo(subtitle1.snp.bottom).offset(30)
             make.left.equalTo(subtitle1)
             make.right.equalToSuperview().offset(-76)
             make.height.equalTo(40)
-        }
-        title2.snp.makeConstraints { make in
+        })
+        title2.snp.makeConstraints({ make in
             make.top.equalTo(textField.snp.bottom).offset(60)
             make.left.equalTo(textField)
-        }
-        subtitle2.snp.makeConstraints { make in
+        })
+        subtitle2.snp.makeConstraints({ make in
             make.top.equalTo(title2.snp.bottom).offset(15)
             make.left.equalTo(title2)
-        }
+        })
     }
     
     // 제목 뷰 가져오기
@@ -113,17 +113,17 @@ class SetPaperViewController: UIViewController {
         
         textField
             .controlPublisher(for: .editingDidEndOnExit)
-            .sink { _ in
+            .sink(receiveValue: { _ in
                 self.input.send(.setPaperTitle(title: textField.text ?? ""))
-            }
+            })
             .store(in: &cancellables)
     
         border.backgroundColor = .black
-        border.snp.makeConstraints { make in
+        border.snp.makeConstraints({ make in
             make.top.equalTo(textField.snp.bottom)
             make.left.right.equalToSuperview()
             make.height.equalTo(2)
-        }
+        })
         
         return textField
     }

--- a/RollingPaper/RollingPaper/Controllers/SetPaperViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/SetPaperViewController.swift
@@ -11,15 +11,16 @@ import Combine
 
 class SetPaperViewController: UIViewController {
     private let paperTitleTextField = UITextField()
-    private let viewModel = SetPaperViewModel()
+    private var viewModel: SetPaperViewModel
     private let input: PassthroughSubject<SetPaperViewModel.Input, Never> = .init()
     private var cancellables = Set<AnyCancellable>()
     private var paper: PaperModel?
     
     // 이전 뷰에서 골랐던 템플릿 설정해주기
     init(template: TemplateEnum) {
+        viewModel = SetPaperViewModel(template: template)
         super.init(nibName: nil, bundle: nil)
-        viewModel.template = template
+        
     }
     
     required init?(coder: NSCoder) {
@@ -45,6 +46,7 @@ class SetPaperViewController: UIViewController {
                     print("페이퍼 생성 성공")
                     // TODO: 페이퍼 객체 넘겨주면서 네비게이션 연결
                     // navigationController?.pushViewController(, animated: true)
+                    print(paper)
                 case .createPaperFail:
                     self.paper = nil
                     print("페이퍼 생성 실패")

--- a/RollingPaper/RollingPaper/Controllers/SetPaperViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/SetPaperViewController.swift
@@ -16,7 +16,7 @@ class SetPaperViewController: UIViewController {
     private var paper: PaperModel?
     
     // 이전 뷰에서 골랐던 템플릿 설정해주기
-    init(template: String) {
+    init(template: TemplateEnum) {
         super.init(nibName: nil, bundle: nil)
         viewModel.template = template
     }

--- a/RollingPaper/RollingPaper/Controllers/TemplateSelectViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/TemplateSelectViewController.swift
@@ -37,7 +37,7 @@ class TemplateSelectViewController: UIViewController {
         let output = viewModel.transform(input: input.eraseToAnyPublisher())
         output
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] event in
+            .sink(receiveValue: { [weak self] event in
                 guard let self = self else {return}
                 switch event {
                 case .getRecentTemplateSuccess(let template):
@@ -46,7 +46,7 @@ class TemplateSelectViewController: UIViewController {
                     self.recentTemplate = nil
                 }
                 self.templateCollectionView?.reloadData()
-            }
+            })
             .store(in: &cancellables)
     }
     
@@ -72,10 +72,10 @@ class TemplateSelectViewController: UIViewController {
         myCollectionView.delegate = self
         
         view.addSubview(myCollectionView)
-        myCollectionView.snp.makeConstraints { make in
+        myCollectionView.snp.makeConstraints({ make in
             make.left.right.bottom.equalToSuperview()
             make.top.equalTo(view.safeAreaLayoutGuide)
-        }
+        })
     }
 }
 
@@ -173,10 +173,10 @@ private class CollectionHeader: UICollectionReusableView {
         addSubview(title)
         
         title.font = .preferredFont(forTextStyle: .largeTitle)
-        title.snp.makeConstraints { make in
+        title.snp.makeConstraints({ make in
             make.top.equalToSuperview().offset(50)
             make.left.equalToSuperview().offset(50)
-        }
+        })
     }
     
     func setHeader(text: String) {
@@ -207,21 +207,21 @@ private class CollectionCell: UICollectionViewCell {
         
         imageView.layer.masksToBounds = true
         imageView.layer.cornerRadius = 12
-        imageView.snp.makeConstraints { make in
+        imageView.snp.makeConstraints({ make in
             make.top.equalToSuperview()
             make.left.equalToSuperview()
             make.width.equalTo(240)
-        }
+        })
         
         title.font = .preferredFont(forTextStyle: .title3)
-        title.snp.makeConstraints { make in
+        title.snp.makeConstraints({ make in
             make.top.equalTo(imageView.snp.bottom).offset(10)
             make.centerX.equalTo(imageView)
-        }
+        })
         
-        thumbnail.snp.makeConstraints { make in
+        thumbnail.snp.makeConstraints({ make in
             make.edges.equalToSuperview()
-        }
+        })
     }
     
     func setCell(template: TemplateModel) {

--- a/RollingPaper/RollingPaper/Controllers/TemplateSelectViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/TemplateSelectViewController.swift
@@ -139,14 +139,17 @@ extension TemplateSelectViewController: UICollectionViewDelegate, UICollectionVi
     
     // 특정 셀 눌렀을 떄의 동작
     func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
-        // TODO: 해당 템플릿으로 이동하기
         // 템플릿을 터치하는 순간 최근 템플릿으로 설정하기 위해 input에 값 설정하기
         if isRecentExist && indexPath.section == 0 {
             guard let recentTemplate = recentTemplate else {return false}
-            input.send(.newTemplateTap(template: recentTemplate))
+            navigationController?.pushViewController(SetPaperViewController(template: recentTemplate), animated: true) {
+                self.input.send(.newTemplateTap(template: recentTemplate))
+            }
         } else {
             let selectedTemplate = viewModel.getTemplates()[indexPath.item]
-            input.send(.newTemplateTap(template: selectedTemplate))
+            navigationController?.pushViewController(SetPaperViewController(template: selectedTemplate), animated: true) {
+                self.input.send(.newTemplateTap(template: selectedTemplate))
+            }
         }
         return true
     }

--- a/RollingPaper/RollingPaper/Resources/UINavigationController+Extensions.swift
+++ b/RollingPaper/RollingPaper/Resources/UINavigationController+Extensions.swift
@@ -1,0 +1,37 @@
+//
+//  UINavigationController+Extensions.swift
+//  RollingPaper
+//
+//  Created by 김동락 on 2022/10/11.
+//
+
+import UIKit
+
+// 네비게이션 애니메이션 끝나면 실행되게 하는 컴플리션
+extension UINavigationController {
+    
+    private func doAfterAnimatingTransition(animated: Bool, completion: @escaping (() -> Void)) {
+        if let coordinator = transitionCoordinator, animated {
+            coordinator.animate(alongsideTransition: nil, completion: { _ in
+                completion()
+            })
+        } else {
+            completion()
+        }
+    }
+    
+    func pushViewController(_ viewController: UIViewController, animated: Bool, completion: @escaping (() -> Void)) {
+        pushViewController(viewController, animated: animated)
+        doAfterAnimatingTransition(animated: animated, completion: completion)
+    }
+    
+    func popViewController(_ animated: Bool, completion: @escaping (() -> Void)) {
+        popViewController(animated: animated)
+        doAfterAnimatingTransition(animated: animated, completion: completion)
+    }
+    
+    func popToRootViewController(_ animated: Bool, completion: @escaping (() -> Void)) {
+        popToRootViewController(animated: animated)
+        doAfterAnimatingTransition(animated: animated, completion: completion)
+    }
+}

--- a/RollingPaper/RollingPaper/ViewModels/SetPaperViewModel.swift
+++ b/RollingPaper/RollingPaper/ViewModels/SetPaperViewModel.swift
@@ -11,11 +11,12 @@ import Combine
 class SetPaperViewModel {
     private var paperTitle: String = ""
     private var paperDurationHour: Int = 2
-    var template: TemplateEnum?
+    private var template: TemplateEnum
     private let databaseManager: LocalDatabaseManager
     
-    init(databaseManager: LocalDatabaseManager = LocalDatabaseMockManager.shared) {
+    init(databaseManager: LocalDatabaseManager = LocalDatabaseMockManager.shared, template: TemplateEnum) {
         self.databaseManager = databaseManager
+        self.template = template
     }
     
     enum Input {
@@ -54,10 +55,7 @@ class SetPaperViewModel {
     // 페이퍼 만들기
     private func createPaper() {
         let currentTime = Date()
-        guard
-            let endTime = Calendar.current.date(byAdding: .hour, value: paperDurationHour, to: currentTime),
-            let template = template
-        else {
+        guard let endTime = Calendar.current.date(byAdding: .hour, value: paperDurationHour, to: currentTime) else {
             output.send(.createPaperFail)
             return
         }

--- a/RollingPaper/RollingPaper/ViewModels/SetPaperViewModel.swift
+++ b/RollingPaper/RollingPaper/ViewModels/SetPaperViewModel.swift
@@ -28,7 +28,7 @@ class SetPaperViewModel {
     
     // 어떤 행동이 Input으로 들어오면 그것에 맞는 행동을 Output에 저장한 뒤 반환해주기
     func transform(input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
-        input.sink { [weak self] event in
+        input.sink(receiveValue: { [weak self] event in
             guard let self = self else {return}
             switch event {
             case .setPaperTitle(let title):
@@ -36,7 +36,7 @@ class SetPaperViewModel {
             case .endSettingPaper:
                 self.createPaper()
             }
-        }
+        })
         .store(in: &cancellables)
         return output.eraseToAnyPublisher()
     }

--- a/RollingPaper/RollingPaper/ViewModels/SetPaperViewModel.swift
+++ b/RollingPaper/RollingPaper/ViewModels/SetPaperViewModel.swift
@@ -12,6 +12,11 @@ class SetPaperViewModel {
     private var paperTitle: String = ""
     private var paperDurationHour: Int = 2
     var template: TemplateEnum?
+    private let databaseManager: LocalDatabaseManager
+    
+    init(databaseManager: LocalDatabaseManager = LocalDatabaseMockManager.shared) {
+        self.databaseManager = databaseManager
+    }
     
     enum Input {
         case setPaperTitle(title: String)
@@ -57,6 +62,7 @@ class SetPaperViewModel {
             return
         }
         let paper = PaperModel(cards: [], date: currentTime, endTime: endTime, title: paperTitle, templateString: template.template.templateString)
+        databaseManager.addPaper(paper: paper)
         output.send(.createPaperSuccess(paper: paper))
     }
 }

--- a/RollingPaper/RollingPaper/ViewModels/SetPaperViewModel.swift
+++ b/RollingPaper/RollingPaper/ViewModels/SetPaperViewModel.swift
@@ -11,7 +11,7 @@ import Combine
 class SetPaperViewModel {
     private var paperTitle: String = ""
     private var paperDurationHour: Int = 2
-    var template: String?
+    var template: TemplateEnum?
     
     enum Input {
         case setPaperTitle(title: String)
@@ -56,7 +56,7 @@ class SetPaperViewModel {
             output.send(.createPaperFail)
             return
         }
-        let paper = PaperModel(cards: [], date: currentTime, endTime: endTime, title: paperTitle, templateString: template)
+        let paper = PaperModel(cards: [], date: currentTime, endTime: endTime, title: paperTitle, templateString: template.template.templateString)
         output.send(.createPaperSuccess(paper: paper))
     }
 }

--- a/RollingPaper/RollingPaper/ViewModels/TemplateSelectViewModel.swift
+++ b/RollingPaper/RollingPaper/ViewModels/TemplateSelectViewModel.swift
@@ -25,7 +25,7 @@ class TemplateSelectViewModel {
     
     // 어떤 행동이 Input으로 들어오면 그것에 맞는 행동을 Output에 저장한 뒤 반환해주기
     func transform(input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
-        input.sink { [weak self] event in
+        input.sink(receiveValue: { [weak self] event in
             guard let self = self else {return}
             switch event {
             case.viewDidAppear:
@@ -34,7 +34,7 @@ class TemplateSelectViewModel {
                 self.saveRecentTemplate(template: template)
                 self.getRecentTemplate()
             }
-        }
+        })
         .store(in: &cancellables)
         return output.eraseToAnyPublisher()
     }


### PR DESCRIPTION
# Issue Number
🔒 Close #47 

## New features
- 사이드 바 -> 템플릿 선택 뷰 -> 페이퍼 설정 뷰 연결
- 네비게이션 바 아이템으로 "생성하기" 버튼 구현
- 배경 터치시 키보드 내려감
- 페이퍼 설정 뷰에서 생성 클릭시 페이퍼 객체 생성 및 로컬에 저장
- Navigation Controller에 대한 Extension 추가 - 화면 전환 애니메이션 끝나면 클로저로 실행할 작업 넣을 수 있음
- TODO: 다음 화면 완성되면 네비게이션으로 잇기만 하면 끝 (생성된 페이퍼 객체 넘겨줄 예정)   

![Simulator Screen Shot - iPad mini (6th generation) - 2022-10-11 at 19 08 57](https://user-images.githubusercontent.com/72330884/195062883-a44c23a6-696f-461f-b583-88743120e551.png)

## References
- https://velog.io/@sun02/iOS-UINavigationBar-%EC%BD%94%EB%93%9C%EB%A1%9C-%EC%9E%91%EC%84%B1%ED%95%98%EA%B8%B0
- https://calmone.tistory.com/entry/iOS-UIKit-in-Swift-4-UIBarButtonItem-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0
- https://blog.naver.com/PostView.nhn?blogId=tngh818&logNo=221707515238

## Checklist

- [X] Is the branch you are merging on correct?
- [X] Do you comply with coding conventions?
- [X] Are there any changes not related to PR?
- [X] Has my code been self-reviewed?
