### PR TITLE
Feature/authmanager refactoring/#75

### DIFF
--- a/RollingPaper/RollingPaper/Managers/FirebaseAuthManager.swift
+++ b/RollingPaper/RollingPaper/Managers/FirebaseAuthManager.swift
@@ -58,7 +58,6 @@ final class FirebaseAuthManager: NSObject, AuthManager {
             .sink(receiveValue: { [weak self] isValid in
                 guard let self = self else { return }
                 if isValid {
-                    print("THIS IS VALID!")
                     self.auth.createUser(withEmail: email, password: password) { [weak self] _, error in
                         guard let self = self else { return }
                         if let error = self.handleError(with: error) {
@@ -78,7 +77,6 @@ final class FirebaseAuthManager: NSObject, AuthManager {
                         }
                     }
                 } else {
-                    print("THIS IS INVALID!")
                     self.signedInSubject.send(.nameAlreadyInUse)
                 }
             })
@@ -273,19 +271,16 @@ final class FirebaseAuthManager: NSObject, AuthManager {
     }
     
     private func updateUserProfile(name: String? = nil, photoURLString: String? = nil) {
-        if
-            let user = auth.currentUser,
-            var currentUser = userProfileSubject.value {
+        
+        if let user = auth.currentUser {
             let changeRequest = user.createProfileChangeRequest()
             if let name = name {
                 changeRequest.displayName = name
-                currentUser.name = name
             }
             if
                 let photoURLString = photoURLString,
                 let photoUrl = URL(string: photoURLString) {
                 changeRequest.photoURL = photoUrl
-                currentUser.profileUrl = photoURLString
             }
             
             changeRequest.commitChanges(completion: { [weak self] error in


### PR DESCRIPTION
# Issue Number
🔒 Close #75 

## New features
- AuthManager의 Sign Up 뒤 유저 정보를 패치하는 타이밍을 조정합니다
- AuthManager의 유저 정보 업데이트에서 사용되는 함수에 적용된 무분별한 weak self → if let self = self ~ 부분을 self?로 간략화, 이전의 store로 계속 담아두던 퍼블리셔를 동작이 끝난 뒤 cancel하는 방식으로 리팩토링하였습니다

- screenshot(optional)

## Review points

- write here

## Questions

- write here

## References

- write here 

## Checklist

- [ ] Is the branch you are merging on correct?
- [ ] Do you comply with coding conventions?
- [ ] Are there any changes not related to PR?
- [ ] Has my code been self-reviewed?
