### PR TITLE
Feature/add data control in paper storage/#87

### DIFF
--- a/RollingPaper/RollingPaper/Controllers/PaperSettingViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/PaperSettingViewController.swift
@@ -44,8 +44,8 @@ class PaperSettingViewController: UIViewController {
                 case .createPaperSuccess(let paper):
                     self.paper = paper
                     print("페이퍼 생성 성공")
-                    // TODO: 페이퍼 객체 넘겨주면서 네비게이션 연결
-                    // navigationController?.pushViewController(, animated: true)
+                    // TODO: 사이먼 뷰로 이동
+                    // navVC.pushViewController(SimonView(), animated: true)
                     print(paper)
                 case .createPaperFail:
                     self.paper = nil

--- a/RollingPaper/RollingPaper/Controllers/PaperStorageViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/PaperStorageViewController.swift
@@ -86,7 +86,7 @@ class PaperStorageViewController: UIViewController {
 extension PaperStorageViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
     // 셀의 사이즈
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return CGSize(width: 200, height: 200)
+        return CGSize(width: 196, height: 169)
     }
     // 섹션별 셀 개수
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {

--- a/RollingPaper/RollingPaper/Controllers/PaperStorageViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/PaperStorageViewController.swift
@@ -80,13 +80,9 @@ class PaperStorageViewController: UIViewController {
         })
     }
     
-    // 페이퍼가 서버에서 다운받은것인지 판별
-    func isFromServer(paperId: String) -> Bool {
-        if viewModel.serverPaperIds.contains(paperId) {
-            return true
-        } else {
-            return false
-        }
+    // 특정 페이퍼를 선택하면 알려주기
+    func setSelectedPaper(paperId: String) {
+        input.send(.paperSelected(paperId: paperId))
     }
 }
 
@@ -144,22 +140,15 @@ extension PaperStorageViewController: UICollectionViewDelegate, UICollectionView
             return UICollectionReusableView()
         }
     }
+    
     // 특정 셀 눌렀을 떄의 동작
     func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
         if indexPath.section == 0 {
-            if viewModel.serverPaperIds.contains(viewModel.openedPapers[indexPath.item].paperId) {
-                FirestoreManager.shared.fetchPaper(paperId: viewModel.openedPapers[indexPath.item].paperId)
-            } else {
-                LocalDatabaseMockManager.shared.fetchPaper(paperId: viewModel.openedPapers[indexPath.item].paperId)
-            }
+            setSelectedPaper(paperId: viewModel.openedPapers[indexPath.item].paperId)
             // TODO: 사이먼 뷰로 이동
             // navVC.pushViewController(SimonView(), animated: true)
         } else {
-            if viewModel.serverPaperIds.contains(viewModel.closedPapers[indexPath.item].paperId) {
-                FirestoreManager.shared.fetchPaper(paperId: viewModel.closedPapers[indexPath.item].paperId)
-            } else {
-                LocalDatabaseMockManager.shared.fetchPaper(paperId: viewModel.closedPapers[indexPath.item].paperId)
-            }
+            setSelectedPaper(paperId: viewModel.closedPapers[indexPath.item].paperId)
             // TODO: 사이먼 뷰로 이동
             // navVC.pushViewController(SimonView(), animated: true)
         }

--- a/RollingPaper/RollingPaper/Controllers/PaperTemplateSelectViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/PaperTemplateSelectViewController.swift
@@ -86,7 +86,7 @@ class PaperTemplateSelectViewController: UIViewController {
 extension PaperTemplateSelectViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
     // 셀 크기
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return CGSize(width: 200, height: 169)
+        return CGSize(width: 196, height: 169)
     }
     
     // 섹션별 셀 개수

--- a/RollingPaper/RollingPaper/Resources/AppDelegate.swift
+++ b/RollingPaper/RollingPaper/Resources/AppDelegate.swift
@@ -69,11 +69,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         let paperView = PaperStorageViewController()
         let navVC = UINavigationController(rootViewController: paperView)
         rootVC.viewControllers[1] = navVC
-        if paperView.isFromServer(paperId: paperId) {
-            FirestoreManager.shared.fetchPaper(paperId: paperId)
-        } else {
-            LocalDatabaseMockManager.shared.fetchPaper(paperId: paperId)
-        }
+        paperView.setSelectedPaper(paperId: paperId)
         // TODO: 사이먼 뷰로 이동
         // navVC.pushViewController(SimonView(), animated: true)
     }

--- a/RollingPaper/RollingPaper/Resources/AppDelegate.swift
+++ b/RollingPaper/RollingPaper/Resources/AppDelegate.swift
@@ -66,12 +66,16 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     // Navigate to Paper View using PaperId
     private func navigatePaperView(paperId: String) {
         guard let rootVC = (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?.window?.rootViewController as? SplitViewController else { return }
-        let navVC = UINavigationController(rootViewController: PaperStorageViewController())
+        let paperView = PaperStorageViewController()
+        let navVC = UINavigationController(rootViewController: paperView)
         rootVC.viewControllers[1] = navVC
-        navVC.pushViewController(SignInViewController(), animated: true)
-        // 루트 뷰: 페이퍼 보관함 카테고리 선택 -> 네비게이션 컨트롤러 캐스팅 및 페이퍼 뷰로 이동
-        // 현재 푸시 노티피케이션 paperId를 해당 페이퍼 뷰에 전달하면서 이니셜라이즈
-//        navVC.pushViewController(SignInViewController(), animated: true)
+        if paperView.isFromServer(paperId: paperId) {
+            FirestoreManager.shared.fetchPaper(paperId: paperId)
+        } else {
+            LocalDatabaseMockManager.shared.fetchPaper(paperId: paperId)
+        }
+        // TODO: 사이먼 뷰로 이동
+        // navVC.pushViewController(SimonView(), animated: true)
     }
     
     /// Register Push Notifctation Permission: (1). AppDelegate (2). After Real Paper activated

--- a/RollingPaper/RollingPaper/ViewModels/PaperStorageViewModel.swift
+++ b/RollingPaper/RollingPaper/ViewModels/PaperStorageViewModel.swift
@@ -101,9 +101,9 @@ class PaperStorageViewModel {
             // 특정 페이퍼가 선택되면 로컬/서버 인지 구분하고 fetchpaper 실행
             case .paperSelected(let paperId):
                 if self.serverPaperIds.contains(paperId) {
-                    FirestoreManager.shared.fetchPaper(paperId: paperId)
+                    self.serverDatabaseManager.fetchPaper(paperId: paperId)
                 } else {
-                    LocalDatabaseMockManager.shared.fetchPaper(paperId: paperId)
+                    self.localDatabaseManager.fetchPaper(paperId: paperId)
                 }
             }
         })

--- a/RollingPaper/RollingPaper/ViewModels/PaperStorageViewModel.swift
+++ b/RollingPaper/RollingPaper/ViewModels/PaperStorageViewModel.swift
@@ -12,6 +12,7 @@ class PaperStorageViewModel {
     enum Input {
         case viewDidAppear
         case viewDidDisappear
+        case paperSelected(paperId: String)
     }
     enum Output {
         case initPapers
@@ -97,6 +98,13 @@ class PaperStorageViewModel {
             // 뷰가 없어졌다는 시그널이 오면 타이머 bind 끊어버림
             case .viewDidDisappear:
                 self.timer?.cancel()
+            // 특정 페이퍼가 선택되면 로컬/서버 인지 구분하고 fetchpaper 실행
+            case .paperSelected(let paperId):
+                if self.serverPaperIds.contains(paperId) {
+                    FirestoreManager.shared.fetchPaper(paperId: paperId)
+                } else {
+                    LocalDatabaseMockManager.shared.fetchPaper(paperId: paperId)
+                }
             }
         })
         .store(in: &cancellables)


### PR DESCRIPTION
# Issue Number
🔒 Close #87

## New features
 - 로컬데이터베이스와 서버데이터베이스에서 각각 페이퍼 목록 가져온 후 만든 날짜 순으로 정렬
 - (진행중 / 종료) 상태와 (서버 / 로컬) 어디서 가져왔는지 각 페이퍼마다 페이퍼 아이디로 구분
 - 페이퍼 아이디로 썸네일 이미지 찾을 수 있도록 함 (딕셔너리 타입)
 - 데이터베이스에서 다운 받을 시 캐시 데이터 먼저 확인, 새로운 데이터를 가져왔다면 캐시에 저장
 - 선택한 페이퍼가 서버 / 로컬 인지에 따라서 실행할 함수(fetchPaper) 달리함
 
## TODO
- 사이먼 뷰로 네비게이션 푸쉬해서 연결
- 페이퍼가 업데이트 될 시 캐시 여부와 상관없이 데이터베이스에서 썸네일 이미지 다시 다운받기

## Checklist

- [X] Is the branch you are merging on correct?
- [X] Do you comply with coding conventions?
- [X] Are there any changes not related to PR?
- [X] Has my code been self-reviewed?
