### PR TITLE
Bug/fix No_Show PencilKit When comback take photo/#129

### DIFF
--- a/RollingPaper/RollingPaper.xcodeproj/project.pbxproj
+++ b/RollingPaper/RollingPaper.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		1573563328FFA80F00EA565B /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 1573563228FFA80F00EA565B /* GoogleService-Info.plist */; };
 		3EA0FA0D1F3A3BD27FEAB304 /* Pods_RollingPaper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63E17153CFE13251542B4A58 /* Pods_RollingPaper.framework */; };
 		AF30AE6D28F907E1002D71C1 /* CardResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF30AE6C28F907E1002D71C1 /* CardResultViewController.swift */; };
+		AF6FEE3C2902E2E400E44E7D /* CameraCustomPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6FEE3B2902E2E400E44E7D /* CameraCustomPicker.swift */; };
 		AFE8D6E928F50319005B1F45 /* CardBackgroundViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE8D6E728F50317005B1F45 /* CardBackgroundViewController.swift */; };
 		AFE8D6EA28F50319005B1F45 /* CardPencilKitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE8D6E828F50319005B1F45 /* CardPencilKitViewController.swift */; };
 		AFE8D6EC28F6618C005B1F45 /* CardRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE8D6EB28F6618C005B1F45 /* CardRootViewController.swift */; };
@@ -85,6 +86,7 @@
 		63E17153CFE13251542B4A58 /* Pods_RollingPaper.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RollingPaper.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9DFFFB53FBA1A9F7D99A1411 /* Pods-RollingPaper.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RollingPaper.release.xcconfig"; path = "Target Support Files/Pods-RollingPaper/Pods-RollingPaper.release.xcconfig"; sourceTree = "<group>"; };
 		AF30AE6C28F907E1002D71C1 /* CardResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardResultViewController.swift; sourceTree = "<group>"; };
+		AF6FEE3B2902E2E400E44E7D /* CameraCustomPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraCustomPicker.swift; sourceTree = "<group>"; };
 		AFE8D6E728F50317005B1F45 /* CardBackgroundViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardBackgroundViewController.swift; sourceTree = "<group>"; };
 		AFE8D6E828F50319005B1F45 /* CardPencilKitViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardPencilKitViewController.swift; sourceTree = "<group>"; };
 		AFE8D6EB28F6618C005B1F45 /* CardRootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardRootViewController.swift; sourceTree = "<group>"; };
@@ -279,6 +281,7 @@
 				AFE8D6E728F50317005B1F45 /* CardBackgroundViewController.swift */,
 				C5F6954928FEDA3800365719 /* WrittenPaperViewController.swift */,
 				1573562E28FFA79B00EA565B /* SettingScreenViewController.swift */,
+				AF6FEE3B2902E2E400E44E7D /* CameraCustomPicker.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -528,6 +531,7 @@
 				D2B6308028EE870D008365CB /* UIControl+Extensions.swift in Sources */,
 				C5F6954C28FEDCF700365719 /* UIButton+Extensions.swift in Sources */,
 				D2B6308E28F16493008365CB /* SignUpTextField.swift in Sources */,
+				AF6FEE3C2902E2E400E44E7D /* CameraCustomPicker.swift in Sources */,
 				D22E4AC428EBFD91001091DA /* SignInViewController.swift in Sources */,
 				D251BDC928ED2A310094ECD9 /* TemplateEnum.swift in Sources */,
 				CFDA52C128F48D08006774E2 /* CategoryModel.swift in Sources */,
@@ -742,14 +746,15 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = RollingPaper/RollingPaper.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 4JPWGVR2ZN;
+				DEVELOPMENT_TEAM = H4DUZUZV8Z;
 				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = RollingPaper/Info.plist;
+				INFOPLIST_KEY_NSCameraUsageDescription = "${PRODUCT_NAME} Camera Private";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "${PRODUCT_NAME} Photo Library Private";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -760,10 +765,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = Yolo.RollingPaper;
+				PRODUCT_BUNDLE_IDENTIFIER = uyggyu;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = YOLO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -777,14 +781,15 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = RollingPaper/RollingPaper.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 4JPWGVR2ZN;
+				DEVELOPMENT_TEAM = H4DUZUZV8Z;
 				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = RollingPaper/Info.plist;
+				INFOPLIST_KEY_NSCameraUsageDescription = "${PRODUCT_NAME} Camera Private";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "${PRODUCT_NAME} Photo Library Private";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -795,10 +800,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = Yolo.RollingPaper;
+				PRODUCT_BUNDLE_IDENTIFIER = uyggyu;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = YOLO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/RollingPaper/RollingPaper/Controllers/CameraCustomPicker.swift
+++ b/RollingPaper/RollingPaper/Controllers/CameraCustomPicker.swift
@@ -1,0 +1,15 @@
+//
+//  CameraCustomPicker.swift
+//  RollingPaper
+//
+//  Created by Yosep on 2022/10/21.
+//
+import Foundation
+import AVFoundation
+import UIKit
+
+class CameraCustomPicker: UIImagePickerController {
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        }
+    }

--- a/RollingPaper/RollingPaper/Controllers/CardBackgroundViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/CardBackgroundViewController.swift
@@ -227,7 +227,7 @@ extension CardBackgroundViewController {
         
         let cameraAction = UIAlertAction(title: "Camera", style: .default) { _ in
             DispatchQueue.main.async(execute: {
-                self.cameraImagePicker(withType: .camera)
+                self.cameraImagePicker()
             })
         }
         
@@ -250,7 +250,7 @@ extension CardBackgroundViewController {
         if let pickedImage = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
             someImageView.image = pickedImage
         }
-        dismiss(animated: true, completion: nil)
+        picker.dismiss(animated: true)
         backgroundImageSend()
     }
     
@@ -258,13 +258,14 @@ extension CardBackgroundViewController {
         self.input.send(.setCardBackgroundImg(background: someImageView.image ?? UIImage(systemName: "heart.fill")!))
     }
     
-    private func cameraImagePicker(withType type: UIImagePickerController.SourceType) {
-        let pickerController = UIImagePickerController()
-        pickerController.delegate = self
-        pickerController.sourceType = type
-        pickerController.cameraFlashMode = .off
-        pickerController.cameraDevice = .front
-        present(pickerController, animated: true)
+    private func cameraImagePicker() {
+        let pushVC = CameraCustomPicker()
+        pushVC.delegate = self
+        pushVC.sourceType = .camera
+        pushVC.cameraFlashMode = .off
+        pushVC.cameraDevice = .front
+        pushVC.modalPresentationStyle = .overFullScreen
+        present(pushVC, animated: true)
     }
     
     private func libraryImagePicker(withType type: UIImagePickerController.SourceType) {
@@ -376,3 +377,4 @@ extension CardBackgroundViewController {
         })
     }
 }
+

--- a/RollingPaper/RollingPaper/Controllers/CardBackgroundViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/CardBackgroundViewController.swift
@@ -255,7 +255,8 @@ extension CardBackgroundViewController {
     }
     
     func backgroundImageSend() {
-        self.input.send(.setCardBackgroundImg(background: someImageView.image ?? UIImage(systemName: "heart.fill")!))
+        guard let image = someImageView.image else { return }
+        self.input.send(.setCardBackgroundImg(background: image))
     }
     
     private func cameraImagePicker() {

--- a/RollingPaper/RollingPaper/Controllers/CardPencilKitViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/CardPencilKitViewController.swift
@@ -12,9 +12,10 @@ import SnapKit
 import Combine
 
 class CardPencilKitViewController: UIViewController, PKCanvasViewDelegate, PKToolPickerObserver {
+    
 
     let toolPicker = PKToolPicker()
-    
+    var drawing = PKDrawing()
     private var arrStickers: [String] = ["Halloween_Pumpkin", "Halloween_Candy", "Halloween_Bat", "Halloween_Ghost", "Halloween_StickCandy", "Halloween_Pumpkin2", "Halloween_Hat", "Halloween_Blood", "Halloween_Ghost2", "Halloween_StickCandy", "Halloween_Pumpkin", "Halloween_Bat", "Halloween_Pumpkin2", "Halloween_StickCandy", "Halloween_Blood"]
     
     private var backgroundImg = UIImage(named: "Rectangle")
@@ -55,7 +56,7 @@ class CardPencilKitViewController: UIViewController, PKCanvasViewDelegate, PKToo
                 selectedStickerView.superview?.bringSubviewToFront(selectedStickerView)
             }
         }
-    } 
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -85,11 +86,6 @@ class CardPencilKitViewController: UIViewController, PKCanvasViewDelegate, PKToo
         bind()
     }
     
-//    override func viewWillAppear(_ animated: Bool) {
-//        super.viewWillAppear(animated)
-//        //canvasViewInteractionEnabled()
-//        //toolPickerAppear()
-//    }
     // TODO: viewDidDisappear이런데에 input 코드 넣으면 네이게이션 돌아 올떄 터짐
     private func bind() {
         let output = viewModel.transform(input: input.eraseToAnyPublisher())

--- a/RollingPaper/RollingPaper/Controllers/CardRootViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/CardRootViewController.swift
@@ -79,7 +79,6 @@ class CardRootViewController: UIViewController {
         customBackBtn.addTarget(self, action: #selector(cancelBtnPressed(_:)), for: .touchUpInside)
         
         let button = UIBarButtonItem(customView: customBackBtn)
-        button.tag = 1
         return button
     }()
     
@@ -91,7 +90,6 @@ class CardRootViewController: UIViewController {
         customCompleteBtn.addTarget(self, action: #selector(openResultView(_:)), for: .touchUpInside)
         
         let button = UIBarButtonItem(customView: customCompleteBtn)
-        button.tag = 2
         return button
     }()
     


### PR DESCRIPTION
# Issue Number
🔒 Close #129

## New features
- 원인은 카메라 컨트롤러가 뜨면서, 카메라 찍는것은 화면전환이 포토라이브러리처럼 모달로 뜨는게 아니라 toolkit 없애버리고 화면 전환되면서 뜸.
- 포토 라이브 러리처럼 모달로 띄우면 해결되지 않을까 생각이 듬. -> animation false주면 UI는 그전과 같음
- 카메라 컨트롤러 클래스를 하나 생성해서, 카메라를 Full Modal로 띄우면 toolkit이 계속 떠 있음 고로 --> 우선 해결됨.

- screenshot(optional)
https://user-images.githubusercontent.com/40324511/197222001-a3e7a819-305c-4b3e-b563-aa806fa1521c.MOV


## Review points
- 사진 찍을때, toolkit 안보이게끔 조치가 필요함,, 물론 Step1부터 진행하고, 스티커 선택하면 안보이기 때문에 크게 크리티컬 하지 않음,

## Checklist

- [ ] Is the branch you are merging on correct?
- [ ] Do you comply with coding conventions?
- [ ] Are there any changes not related to PR?
- [ ] Has my code been self-reviewed?
