### PR TITLE
Feature/signupinview refact/#128

### DIFF
--- a/RollingPaper/RollingPaper/Controllers/SignInViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/SignInViewController.swift
@@ -290,7 +290,10 @@ class SignInViewController: UIViewController {
             let splitVC = presentingViewController as? SplitViewController,
             let currentNavVC = splitVC.viewControllers[1] as? UINavigationController,
             let currentVC = currentNavVC.viewControllers.last as? WrittenPaperViewController {
+            // dismiss and connect to server paper flow
             dismiss(animated: true)
+        } else {
+            // Call SplitVC and refresh this settingView
         }
     }
     
@@ -310,7 +313,6 @@ class SignInViewController: UIViewController {
                     self.setTextFieldUI(textFieldFocused: .passwordWaring)
                 case .signInDidSuccess:
                     self.setWarningMessage(isShown: false, message: nil)
-                    // navigate to current view flow (dismiss, etc...)
                     self.navigateToCurrentFlow()
                 case .emailFocused:
                     self.setWarningMessage(isShown: false, message: nil)

--- a/RollingPaper/RollingPaper/Controllers/SignInViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/SignInViewController.swift
@@ -111,40 +111,21 @@ class SignInViewController: UIViewController {
         setKeyboardObserver()
     }
     
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        let topOffset = (UIScreen.main.bounds.height - 246) / 2
-        emailTextField.snp.updateConstraints({ make in
-            make.top.equalToSuperview().offset(topOffset)
-        })
-        view.layoutIfNeeded()
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        layoutIfModalView()
     }
     
-    private func setKeyboardObserver() {
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
-    }
-    
-    @objc private func keyboardWillShow(notification: NSNotification) {
-        if
-            let userInfo = notification.userInfo,
-            let keyboardInfo = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
-            let keyboardRect = keyboardInfo.cgRectValue
-            let keyboardY = keyboardRect.origin.y
-            let originalHeight = UIScreen.main.bounds.height
-            let currentViewHeight = view.frame.height
-            let offsetHeight = (originalHeight - currentViewHeight) / 2
-            if currentFocusedTextfieldY + offsetHeight + 38 > keyboardY {
-                view.frame.origin.y = keyboardY - currentFocusedTextfieldY - 38 - offsetHeight
-            }
+    private func layoutIfModalView() {
+        if presentingViewController != nil {
+            let topOffset = (view.frame.height - 332) / 2
+            emailTextField.snp.updateConstraints({ make in
+                make.top.equalToSuperview().offset(topOffset)
+            })
+            view.layoutIfNeeded()
         }
     }
     
-    @objc private func keyboardWillHide(notification: NSNotification) {
-        if view.frame.origin.y != 0 {
-            view.frame.origin.y = 0
-        }
-    }
-        
     private func setSignInViewUI() {
         view.backgroundColor = .systemBackground
         view.addSubviews([emailTextField, passwordTextField, waringImage, waringLabel, signUpButton, signUpDivider, signInButton, divider, appleSignInButton])
@@ -200,54 +181,6 @@ class SignInViewController: UIViewController {
             make.centerX.equalToSuperview()
         })
         setCloseButton()
-    }
-    
-    private func setCloseButton() {
-        if presentingViewController != nil {
-            navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "xmark")?.withTintColor(.black, renderingMode: .alwaysOriginal), style: .done, target: self, action: #selector(close))
-        }
-    }
-    
-    @objc private func close() {
-        dismiss(animated: true)
-    }
-    
-    private func handleError(error: AuthManagerEnum) {
-        switch error {
-        case .userNotFound:
-            setWarningMessage(isShown: true, message: "이메일이 존재하지 않습니다")
-            setTextFieldUI(textFieldFocused: .emailWaring)
-        case .userTokenExpired:
-            setWarningMessage(isShown: true, message: "이메일 토큰이 만료되었습니다")
-            setTextFieldUI(textFieldFocused: .emailWaring)
-        case .emailAlreadyInUse:
-            setWarningMessage(isShown: true, message: "이미 사용 중인 이메일입니다")
-            setTextFieldUI(textFieldFocused: .emailWaring)
-        case .wrongPassword:
-            setWarningMessage(isShown: true, message: "비밀번호가 틀렸습니다")
-            setTextFieldUI(textFieldFocused: .passwordWaring)
-        case .invalidEmail:
-            setWarningMessage(isShown: true, message: "입력된 이메일 주소를 확인해주세요")
-            setTextFieldUI(textFieldFocused: .emailWaring)
-        case .unknownError:
-            setWarningMessage(isShown: true, message: "알 수 없는 오류입니다")
-            setTextFieldUI(textFieldFocused: .bothWaring)
-        default:
-            setWarningMessage(isShown: true, message: "알 수 없는 오류입니다")
-            setTextFieldUI(textFieldFocused: .bothWaring)
-        }
-    }
-    
-    private func setWarningMessage(isShown: Bool, message: String?) {
-        waringLabel.isHidden = !isShown
-        waringImage.isHidden = !isShown
-        if let message = message {
-            waringLabel.text = message
-        }
-        signUpButton.snp.updateConstraints({ make in
-            make.top.equalTo(passwordTextField.snp.bottom).offset(isShown ? 69 : 36)
-        })
-        view.layoutIfNeeded()
     }
     
     private func setTextFieldUI(textFieldFocused: TextFieldFocused) {
@@ -422,6 +355,9 @@ class SignInViewController: UIViewController {
                         splitVC.present(navVC, animated: true)
                     }
                 } else {
+                    let backButtonItem = UIBarButtonItem(title: "로그인", style: .plain, target: self, action: nil)
+                    backButtonItem.tintColor = .systemGray
+                    self?.navigationItem.backBarButtonItem = backButtonItem
                     self?.navigationController?.pushViewController(SignUpViewController(), animated: true)
                 }
             })
@@ -434,5 +370,82 @@ class SignInViewController: UIViewController {
         view.endEditing(true)
         emailTextField.resignFirstResponder()
         passwordTextField.resignFirstResponder()
+    }
+}
+
+extension SignInViewController {
+    private func setKeyboardObserver() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    @objc private func keyboardWillShow(notification: NSNotification) {
+        if
+            let userInfo = notification.userInfo,
+            let keyboardInfo = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
+            let keyboardRect = keyboardInfo.cgRectValue
+            let keyboardY = keyboardRect.origin.y
+            let originalHeight = UIScreen.main.bounds.height
+            let currentViewHeight = view.frame.height
+            let offsetHeight = (originalHeight - currentViewHeight) / 2
+            print(originalHeight, currentViewHeight, offsetHeight, currentFocusedTextfieldY, keyboardY)
+            if currentFocusedTextfieldY + offsetHeight + 38 > keyboardY {
+                view.frame.origin.y = keyboardY - currentFocusedTextfieldY - 38 - offsetHeight
+            }
+        }
+    }
+    
+    @objc private func keyboardWillHide(notification: NSNotification) {
+        if view.frame.origin.y != 0 {
+            view.frame.origin.y = 0
+        }
+    }
+    
+    private func setCloseButton() {
+        if presentingViewController != nil {
+            navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "xmark")?.withTintColor(.black, renderingMode: .alwaysOriginal), style: .done, target: self, action: #selector(close))
+        }
+    }
+    
+    @objc private func close() {
+        dismiss(animated: true)
+    }
+    
+    private func handleError(error: AuthManagerEnum) {
+        switch error {
+        case .userNotFound:
+            setWarningMessage(isShown: true, message: "이메일이 존재하지 않습니다")
+            setTextFieldUI(textFieldFocused: .emailWaring)
+        case .userTokenExpired:
+            setWarningMessage(isShown: true, message: "이메일 토큰이 만료되었습니다")
+            setTextFieldUI(textFieldFocused: .emailWaring)
+        case .emailAlreadyInUse:
+            setWarningMessage(isShown: true, message: "이미 사용 중인 이메일입니다")
+            setTextFieldUI(textFieldFocused: .emailWaring)
+        case .wrongPassword:
+            setWarningMessage(isShown: true, message: "비밀번호가 틀렸습니다")
+            setTextFieldUI(textFieldFocused: .passwordWaring)
+        case .invalidEmail:
+            setWarningMessage(isShown: true, message: "입력된 이메일 주소를 확인해주세요")
+            setTextFieldUI(textFieldFocused: .emailWaring)
+        case .unknownError:
+            setWarningMessage(isShown: true, message: "알 수 없는 오류입니다")
+            setTextFieldUI(textFieldFocused: .bothWaring)
+        default:
+            setWarningMessage(isShown: true, message: "알 수 없는 오류입니다")
+            setTextFieldUI(textFieldFocused: .bothWaring)
+        }
+    }
+    
+    private func setWarningMessage(isShown: Bool, message: String?) {
+        waringLabel.isHidden = !isShown
+        waringImage.isHidden = !isShown
+        if let message = message {
+            waringLabel.text = message
+        }
+        signUpButton.snp.updateConstraints({ make in
+            make.top.equalTo(passwordTextField.snp.bottom).offset(isShown ? 69 : 36)
+        })
+        view.layoutIfNeeded()
     }
 }

--- a/RollingPaper/RollingPaper/Controllers/SignInViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/SignInViewController.swift
@@ -165,7 +165,7 @@ class SignInViewController: UIViewController {
             make.leading.equalTo(waringImage.snp.trailing).offset(11.48)
         })
         signUpLabel.snp.makeConstraints({ make in
-            make.top.equalTo(waringLabel.snp.bottom).offset(32)
+            make.top.equalTo(passwordTextField.snp.bottom).offset(36)
             make.centerX.equalToSuperview()
         })
         signInButton.snp.makeConstraints({ make in
@@ -220,8 +220,8 @@ class SignInViewController: UIViewController {
         if let message = message {
             waringLabel.text = message
         }
-        signInButton.snp.updateConstraints({ make in
-            make.top.equalTo(passwordTextField.snp.bottom).offset(isShown ? 80 : 28)
+        signUpLabel.snp.updateConstraints({ make in
+            make.top.equalTo(passwordTextField.snp.bottom).offset(isShown ? 69 : 36)
         })
         view.layoutIfNeeded()
     }

--- a/RollingPaper/RollingPaper/Controllers/SignInViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/SignInViewController.swift
@@ -130,8 +130,11 @@ class SignInViewController: UIViewController {
             let keyboardInfo = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
             let keyboardRect = keyboardInfo.cgRectValue
             let keyboardY = keyboardRect.origin.y
-            if currentFocusedTextfieldY + 38 > keyboardY {
-                view.frame.origin.y = keyboardY - currentFocusedTextfieldY - 38
+            let originalHeight = UIScreen.main.bounds.height
+            let currentViewHeight = view.frame.height
+            let offsetHeight = (originalHeight - currentViewHeight) / 2
+            if currentFocusedTextfieldY + offsetHeight + 38 > keyboardY {
+                view.frame.origin.y = keyboardY - currentFocusedTextfieldY - 38 - offsetHeight
             }
         }
     }
@@ -145,7 +148,7 @@ class SignInViewController: UIViewController {
     private func setSignInViewUI() {
         view.backgroundColor = .systemBackground
         view.addSubviews([emailTextField, passwordTextField, waringImage, waringLabel, signUpButton, signUpDivider, signInButton, divider, appleSignInButton])
-        let topOffset = (UIScreen.main.bounds.height - 246) / 2
+        let topOffset = (view.frame.height - 332) / 2
         emailTextField.snp.makeConstraints({ make in
             make.top.equalToSuperview().offset(topOffset)
             make.centerX.equalToSuperview()
@@ -407,7 +410,18 @@ class SignInViewController: UIViewController {
         signUpButton
             .tapPublisher
             .sink(receiveValue: { [weak self] _ in
-                self?.navigationController?.pushViewController(SignUpViewController(), animated: true)
+                if
+                    let splitVC = self?.presentingViewController as? SplitViewController,
+                    let currentNavVC = splitVC.viewControllers[1] as? UINavigationController {
+                    currentNavVC.dismiss(animated: true) {
+                        let signUpVC = SignUpViewController()
+                        let navVC = UINavigationController(rootViewController: signUpVC)
+                        navVC.modalPresentationStyle = .pageSheet
+                        splitVC.present(navVC, animated: true)
+                    }
+                } else {
+                    self?.navigationController?.pushViewController(SignUpViewController(), animated: true)
+                }
             })
             .store(in: &cancellables)
         let backgroundGesture = UITapGestureRecognizer(target: self, action: #selector(backgroundDidTap))

--- a/RollingPaper/RollingPaper/Controllers/SignInViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/SignInViewController.swift
@@ -271,6 +271,15 @@ class SignInViewController: UIViewController {
         }
     }
     
+    private func navigateToCurrentFlow() {
+        if
+            let splitVC = presentingViewController as? SplitViewController,
+            let currentNavVC = splitVC.viewControllers[1] as? UINavigationController,
+            let currentVC = currentNavVC.viewControllers.last as? WrittenPaperViewController {
+            dismiss(animated: true)
+        }
+    }
+    
     private func bind() {
         let output = viewModel.transform(input: input.eraseToAnyPublisher())
         output
@@ -288,6 +297,7 @@ class SignInViewController: UIViewController {
                 case .signInDidSuccess:
                     self.setWarningMessage(isShown: false, message: nil)
                     // navigate to current view flow (dismiss, etc...)
+                    self.navigateToCurrentFlow()
                 case .emailFocused:
                     self.setWarningMessage(isShown: false, message: nil)
                     self.setTextFieldUI(textFieldFocused: .emailFocused)
@@ -381,6 +391,12 @@ class SignInViewController: UIViewController {
             .sink(receiveValue: { [weak self] _ in
                 self?.input.send(.normalBoundTap)
                 self?.passwordTextField.resignFirstResponder()
+            })
+            .store(in: &cancellables)
+        signUpButton
+            .tapPublisher
+            .sink(receiveValue: { [weak self] _ in
+                self?.navigationController?.pushViewController(SignUpViewController(), animated: true)
             })
             .store(in: &cancellables)
         let backgroundGesture = UITapGestureRecognizer(target: self, action: #selector(backgroundDidTap))

--- a/RollingPaper/RollingPaper/Controllers/SignInViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/SignInViewController.swift
@@ -50,13 +50,17 @@ class SignInViewController: UIViewController {
         textField.leftViewMode = .always
         return textField
     }()
-    private let signUpLabel: UILabel = {
-        let label = UILabel()
-        label.text = "계정 만들기"
-        label.textColor = .systemGray
-        label.font = .preferredFont(forTextStyle: .body)
-        label.textAlignment = .center
-        return label
+    private let signUpButton: UIButton = {
+        let button = UIButton()
+        let title = NSAttributedString(string: "계정 만들기", attributes: [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .body), NSAttributedString.Key.foregroundColor: UIColor.systemGray])
+        button.setAttributedTitle(title, for: .normal)
+        return button
+    }()
+    private let signUpDivider: UIView = {
+        let view = UIView()
+        view.backgroundColor = .systemGray
+        view.layer.masksToBounds = true
+        return view
     }()
     private let signInButton: UIButton = {
         let button = UIButton()
@@ -71,7 +75,7 @@ class SignInViewController: UIViewController {
     }()
     private let divider: UIView = {
         let view = UIView()
-        view.backgroundColor = UIColor.gray
+        view.backgroundColor = UIColor.systemGray
         view.layer.masksToBounds = true
         return view
     }()
@@ -140,7 +144,7 @@ class SignInViewController: UIViewController {
         
     private func setSignInViewUI() {
         view.backgroundColor = .systemBackground
-        view.addSubviews([emailTextField, passwordTextField, waringImage, waringLabel, signUpLabel, signInButton, divider, appleSignInButton])
+        view.addSubviews([emailTextField, passwordTextField, waringImage, waringLabel, signUpButton, signUpDivider, signInButton, divider, appleSignInButton])
         let topOffset = (UIScreen.main.bounds.height - 246) / 2
         emailTextField.snp.makeConstraints({ make in
             make.top.equalToSuperview().offset(topOffset)
@@ -164,12 +168,18 @@ class SignInViewController: UIViewController {
             make.top.equalTo(waringImage.snp.top)
             make.leading.equalTo(waringImage.snp.trailing).offset(11.48)
         })
-        signUpLabel.snp.makeConstraints({ make in
+        signUpButton.snp.makeConstraints({ make in
             make.top.equalTo(passwordTextField.snp.bottom).offset(36)
             make.centerX.equalToSuperview()
         })
+        signUpDivider.snp.makeConstraints({ make in
+            make.top.equalTo(signUpButton.snp.bottom).offset(-5.75)
+            make.width.equalTo(signUpButton.snp.width)
+            make.height.equalTo(1)
+            make.leading.equalTo(signUpButton.snp.leading)
+        })
         signInButton.snp.makeConstraints({ make in
-            make.top.equalTo(signUpLabel.snp.bottom).offset(36)
+            make.top.equalTo(signUpButton.snp.bottom).offset(36)
             make.width.equalTo(375)
             make.height.equalTo(48)
             make.centerX.equalToSuperview()
@@ -220,7 +230,7 @@ class SignInViewController: UIViewController {
         if let message = message {
             waringLabel.text = message
         }
-        signUpLabel.snp.updateConstraints({ make in
+        signUpButton.snp.updateConstraints({ make in
             make.top.equalTo(passwordTextField.snp.bottom).offset(isShown ? 69 : 36)
         })
         view.layoutIfNeeded()

--- a/RollingPaper/RollingPaper/Controllers/SignInViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/SignInViewController.swift
@@ -196,6 +196,17 @@ class SignInViewController: UIViewController {
             make.height.equalTo(48)
             make.centerX.equalToSuperview()
         })
+        setCloseButton()
+    }
+    
+    private func setCloseButton() {
+        if presentingViewController != nil {
+            navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "xmark")?.withTintColor(.black, renderingMode: .alwaysOriginal), style: .done, target: self, action: #selector(close))
+        }
+    }
+    
+    @objc private func close() {
+        dismiss(animated: true)
     }
     
     private func handleError(error: AuthManagerEnum) {
@@ -270,7 +281,7 @@ class SignInViewController: UIViewController {
             passwordTextField.layer.borderColor = UIColor.systemRed.cgColor
         }
     }
-    
+        
     private func navigateToCurrentFlow() {
         if
             let splitVC = presentingViewController as? SplitViewController,

--- a/RollingPaper/RollingPaper/Controllers/SignInViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/SignInViewController.swift
@@ -50,14 +50,30 @@ class SignInViewController: UIViewController {
         textField.leftViewMode = .always
         return textField
     }()
+    private let signUpLabel: UILabel = {
+        let label = UILabel()
+        label.text = "계정 만들기"
+        label.textColor = .systemGray
+        label.font = .preferredFont(forTextStyle: .body)
+        label.textAlignment = .center
+        return label
+    }()
     private let signInButton: UIButton = {
         let button = UIButton()
-        button.backgroundColor = UIColor(rgb: 0x007AFF)
+        button.backgroundColor = .white
         button.layer.cornerRadius = 12
+        button.layer.borderColor = UIColor.black.cgColor
+        button.layer.borderWidth = 1.0
         button.layer.masksToBounds = true
-        let title = NSAttributedString(string: "로그인", attributes: [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .title3), NSAttributedString.Key.foregroundColor: UIColor.white])
+        let title = NSAttributedString(string: "로그인", attributes: [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .title3), NSAttributedString.Key.foregroundColor: UIColor.label])
         button.setAttributedTitle(title, for: .normal)
         return button
+    }()
+    private let divider: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor.gray
+        view.layer.masksToBounds = true
+        return view
     }()
     private let appleSignInButton: ASAuthorizationAppleIDButton = {
         let button = ASAuthorizationAppleIDButton(type: .signIn, style: .black)
@@ -124,7 +140,7 @@ class SignInViewController: UIViewController {
         
     private func setSignInViewUI() {
         view.backgroundColor = .systemBackground
-        view.addSubviews([emailTextField, passwordTextField, waringImage, waringLabel, signInButton, appleSignInButton])
+        view.addSubviews([emailTextField, passwordTextField, waringImage, waringLabel, signUpLabel, signInButton, divider, appleSignInButton])
         let topOffset = (UIScreen.main.bounds.height - 246) / 2
         emailTextField.snp.makeConstraints({ make in
             make.top.equalToSuperview().offset(topOffset)
@@ -148,14 +164,24 @@ class SignInViewController: UIViewController {
             make.top.equalTo(waringImage.snp.top)
             make.leading.equalTo(waringImage.snp.trailing).offset(11.48)
         })
+        signUpLabel.snp.makeConstraints({ make in
+            make.top.equalTo(waringLabel.snp.bottom).offset(32)
+            make.centerX.equalToSuperview()
+        })
         signInButton.snp.makeConstraints({ make in
-            make.top.equalTo(passwordTextField.snp.bottom).offset(28)
+            make.top.equalTo(signUpLabel.snp.bottom).offset(36)
             make.width.equalTo(375)
             make.height.equalTo(48)
             make.centerX.equalToSuperview()
         })
+        divider.snp.makeConstraints({ make in
+            make.width.equalTo(340)
+            make.height.equalTo(2)
+            make.top.equalTo(signInButton.snp.bottom).offset(24)
+            make.centerX.equalToSuperview()
+        })
         appleSignInButton.snp.makeConstraints({ make in
-            make.top.equalTo(signInButton.snp.bottom).offset(28)
+            make.top.equalTo(divider.snp.bottom).offset(24)
             make.width.equalTo(375)
             make.height.equalTo(48)
             make.centerX.equalToSuperview()

--- a/RollingPaper/RollingPaper/Controllers/SignUpViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/SignUpViewController.swift
@@ -287,19 +287,22 @@ class SignUpViewController: UIViewController {
             .tapPublisher
             .receive(on: DispatchQueue.main)
             .sink(receiveValue: { [weak self] _ in
-                self?.navigateToSignInView()
+                if
+                    let splitVC = self?.presentingViewController as? SplitViewController,
+                    let currentNavVC = splitVC.viewControllers[1] as? UINavigationController {
+                    currentNavVC.dismiss(animated: true) {
+                        let signInVC = SignInViewController()
+                        let navVC = UINavigationController(rootViewController: signInVC)
+                        navVC.modalPresentationStyle = .pageSheet
+                        splitVC.present(navVC, animated: true)
+                    }
+                } else {
+                    self?.navigationController?.popViewController(animated: true)
+                }
             })
             .store(in: &cancellables)
         let backgroundGesture = UITapGestureRecognizer(target: self, action: #selector(backgroundDidTap))
         view.addGestureRecognizer(backgroundGesture)
-    }
-    
-    private func navigateToSignInView() {
-        if presentingViewController != nil {
-            
-        } else {
-            navigationController?.popViewController(animated: true)
-        }
     }
     
     private func setCloseButton() {

--- a/RollingPaper/RollingPaper/Controllers/SignUpViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/SignUpViewController.swift
@@ -23,6 +23,18 @@ class SignUpViewController: UIViewController {
         let textField = SignUpTextField()
         return textField
     }()
+    private let signInButton: UIButton = {
+        let button = UIButton()
+        let title = NSAttributedString(string: "로그인", attributes: [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .body), NSAttributedString.Key.foregroundColor: UIColor.systemGray])
+        button.setAttributedTitle(title, for: .normal)
+        return button
+    }()
+    private let signInDivider: UIView = {
+        let view = UIView()
+        view.backgroundColor = .systemGray
+        view.layer.masksToBounds = true
+        return view
+    }()
     private let signUpButton: UIButton = {
         let button = UIButton()
         button.backgroundColor = .systemGray
@@ -78,7 +90,7 @@ class SignUpViewController: UIViewController {
     
     private func setSignUpViewUI() {
         view.backgroundColor = .systemBackground
-        view.addSubviews([emailTextField, passwordTextField, nameTextField, signUpButton])
+        view.addSubviews([emailTextField, passwordTextField, nameTextField, signInButton, signInDivider, signUpButton])
         let topOffset = (UIScreen.main.bounds.height - 380) / 2
         emailTextField.snp.makeConstraints({ make in
             make.top.equalToSuperview().offset(topOffset)
@@ -98,12 +110,23 @@ class SignUpViewController: UIViewController {
             make.width.equalTo(380)
         })
         nameTextField.setTextFieldType(type: .name)
+        signInButton.snp.makeConstraints({ make in
+            make.top.equalTo(nameTextField.snp.top).offset(nameTextField.frame.height + 32)
+            make.centerX.equalToSuperview()
+        })
+        signInDivider.snp.makeConstraints({ make in
+            make.top.equalTo(signInButton.snp.bottom).offset(-5.75)
+            make.width.equalTo(signInButton.snp.width)
+            make.height.equalTo(1)
+            make.leading.equalTo(signInButton.snp.leading)
+        })
         signUpButton.snp.makeConstraints({ make in
-            make.top.equalTo(nameTextField.snp.top).offset(passwordTextField.frame.height + 32)
+            make.top.equalTo(signInButton.snp.bottom).offset(36)
             make.centerX.equalToSuperview()
             make.width.equalTo(380)
             make.height.equalTo(38)
         })
+        setCloseButton()
     }
     
     private func bind() {
@@ -260,6 +283,16 @@ class SignUpViewController: UIViewController {
         let backgroundGesture = UITapGestureRecognizer(target: self, action: #selector(backgroundDidTap))
         view.addGestureRecognizer(backgroundGesture)
     }
+    
+    private func setCloseButton() {
+        if presentingViewController != nil {
+            navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "xmark")?.withTintColor(.black, renderingMode: .alwaysOriginal), style: .done, target: self, action: #selector(close))
+        }
+    }
+    
+    @objc private func close() {
+        dismiss(animated: true)
+    }
 }
 
 extension SignUpViewController {
@@ -294,8 +327,8 @@ extension SignUpViewController {
                 make.top.equalTo(passwordTextField.snp.top).offset(isWaringShown ? passwordTextField.frame.height + 28 : 66)
             })
         case .name:
-            signUpButton.snp.updateConstraints({ make in
-                make.top.equalTo(nameTextField.snp.top).offset(isWaringShown ? nameTextField.frame.height + 32 : 70)
+            signInButton.snp.updateConstraints({ make in
+                make.top.equalTo(nameTextField.snp.top).offset(isWaringShown ? nameTextField.frame.height + 32 : 74)
             })
         }
         view.layoutIfNeeded()

--- a/RollingPaper/RollingPaper/Controllers/SignUpViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/SignUpViewController.swift
@@ -76,8 +76,11 @@ class SignUpViewController: UIViewController {
             let keyboardInfo = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
             let keyboardRect = keyboardInfo.cgRectValue
             let keyboardY = keyboardRect.origin.y
-            if currentFocusedTextfieldY + 38 > keyboardY {
-                self.view.frame.origin.y =  keyboardY - currentFocusedTextfieldY - 38
+            let originalHeight = UIScreen.main.bounds.height
+            let currentViewHeight = view.frame.height
+            let offsetHeight = (originalHeight - currentViewHeight) / 2
+            if currentFocusedTextfieldY + offsetHeight + 38 > keyboardY {
+                view.frame.origin.y = keyboardY - currentFocusedTextfieldY - 38 - offsetHeight
             }
         }
     }
@@ -280,8 +283,23 @@ class SignUpViewController: UIViewController {
                 self?.setTextfieldLayout(textFieldType: .name, isWaringShown: isWaringShown)
             })
             .store(in: &cancellables)
+        signInButton
+            .tapPublisher
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: { [weak self] _ in
+                self?.navigateToSignInView()
+            })
+            .store(in: &cancellables)
         let backgroundGesture = UITapGestureRecognizer(target: self, action: #selector(backgroundDidTap))
         view.addGestureRecognizer(backgroundGesture)
+    }
+    
+    private func navigateToSignInView() {
+        if presentingViewController != nil {
+            
+        } else {
+            navigationController?.popViewController(animated: true)
+        }
     }
     
     private func setCloseButton() {

--- a/RollingPaper/RollingPaper/Controllers/SignUpViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/SignUpViewController.swift
@@ -57,12 +57,9 @@ class SignUpViewController: UIViewController {
         setKeyboardObserver()
     }
     
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        let topOffset = (UIScreen.main.bounds.height - 380) / 2
-        emailTextField.snp.updateConstraints({ make in
-            make.top.equalToSuperview().offset(topOffset)
-        })
-        view.layoutIfNeeded()
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        layoutIfModalView()
     }
     
     private func setKeyboardObserver() {
@@ -91,10 +88,20 @@ class SignUpViewController: UIViewController {
         }
     }
     
+    private func layoutIfModalView() {
+        if presentingViewController != nil {
+            let topOffset = (view.frame.height - 380) / 2
+            emailTextField.snp.updateConstraints({ make in
+                make.top.equalToSuperview().offset(topOffset)
+            })
+            view.layoutIfNeeded()
+        }
+    }
+    
     private func setSignUpViewUI() {
         view.backgroundColor = .systemBackground
         view.addSubviews([emailTextField, passwordTextField, nameTextField, signInButton, signInDivider, signUpButton])
-        let topOffset = (UIScreen.main.bounds.height - 380) / 2
+        let topOffset = (view.frame.height - 380) / 2
         emailTextField.snp.makeConstraints({ make in
             make.top.equalToSuperview().offset(topOffset)
             make.centerX.equalToSuperview()
@@ -141,7 +148,8 @@ class SignUpViewController: UIViewController {
                 case .signUpDidFail(error: let error):
                     self?.handleError(error: error)
                 case .signUpDidSuccess:
-                    print("Successfully Signed Up")
+                    //TODO: mark sign up success
+                    self?.navigateToSignIn()
                 }
             })
             .store(in: &cancellables)
@@ -287,22 +295,26 @@ class SignUpViewController: UIViewController {
             .tapPublisher
             .receive(on: DispatchQueue.main)
             .sink(receiveValue: { [weak self] _ in
-                if
-                    let splitVC = self?.presentingViewController as? SplitViewController,
-                    let currentNavVC = splitVC.viewControllers[1] as? UINavigationController {
-                    currentNavVC.dismiss(animated: true) {
-                        let signInVC = SignInViewController()
-                        let navVC = UINavigationController(rootViewController: signInVC)
-                        navVC.modalPresentationStyle = .pageSheet
-                        splitVC.present(navVC, animated: true)
-                    }
-                } else {
-                    self?.navigationController?.popViewController(animated: true)
-                }
+                self?.navigateToSignIn()
             })
             .store(in: &cancellables)
         let backgroundGesture = UITapGestureRecognizer(target: self, action: #selector(backgroundDidTap))
         view.addGestureRecognizer(backgroundGesture)
+    }
+    
+    private func navigateToSignIn() {
+        if
+            let splitVC = presentingViewController as? SplitViewController,
+            let currentNavVC = splitVC.viewControllers[1] as? UINavigationController {
+            currentNavVC.dismiss(animated: true) {
+                let signInVC = SignInViewController()
+                let navVC = UINavigationController(rootViewController: signInVC)
+                navVC.modalPresentationStyle = .pageSheet
+                splitVC.present(navVC, animated: true)
+            }
+        } else {
+            navigationController?.popViewController(animated: true)
+        }
     }
     
     private func setCloseButton() {

--- a/RollingPaper/RollingPaper/Controllers/WrittenPaperViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/WrittenPaperViewController.swift
@@ -162,9 +162,10 @@ class WrittenPaperViewController: UIViewController {
     }
     
     func presentSignUpModal(_ sender: UIButton) {
-        let signUpVC = SignUpViewController()
-        signUpVC.modalPresentationStyle = UIModalPresentationStyle.formSheet
-        self.present(signUpVC, animated: true)
+        let signUpVC = SignInViewController()
+        let navVC = UINavigationController(rootViewController: signUpVC)
+        navVC.modalPresentationStyle = UIModalPresentationStyle.fullScreen
+        self.present(navVC, animated: true)
     }
     
     func setPopOverView(_ sender: UIButton) {

--- a/RollingPaper/RollingPaper/Controllers/WrittenPaperViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/WrittenPaperViewController.swift
@@ -162,10 +162,10 @@ class WrittenPaperViewController: UIViewController {
     }
     
     func presentSignUpModal(_ sender: UIButton) {
-        let signUpVC = SignInViewController()
-        let navVC = UINavigationController(rootViewController: signUpVC)
-        navVC.modalPresentationStyle = UIModalPresentationStyle.fullScreen
-        self.present(navVC, animated: true)
+        let signInVC = SignInViewController()
+        let navVC = UINavigationController(rootViewController: signInVC)
+        navVC.modalPresentationStyle = .formSheet
+        present(navVC, animated: true)
     }
     
     func setPopOverView(_ sender: UIButton) {

--- a/RollingPaper/RollingPaper/ViewModels/WrittenPaperViewModel.swift
+++ b/RollingPaper/RollingPaper/ViewModels/WrittenPaperViewModel.swift
@@ -38,7 +38,7 @@ class WrittenPaperViewModel {
 
     private var cards: [CardModel] = []
     
-    init(localDatabaseManager: DatabaseManager = LocalDatabaseMockManager.shared, serverDatabaseManager: DatabaseManager = FirestoreManager.shared) {
+    init(localDatabaseManager: DatabaseManager = LocalDatabaseFileManager.shared, serverDatabaseManager: DatabaseManager = FirestoreManager.shared) {
         self.localDatabaseManager = localDatabaseManager
         self.serverDatabaseManager = serverDatabaseManager
         print("WrittenViewModel Init")

--- a/RollingPaper/RollingPaper/Views/SignUpTextField.swift
+++ b/RollingPaper/RollingPaper/Views/SignUpTextField.swift
@@ -233,7 +233,7 @@ extension SignUpTextField {
                 textField.layer.borderWidth = 1.0
                 textField.layer.shadowOpacity = 0.0
                 checkImageView.isHidden = true
-                setWaringView(waringShown: false, text: "비밀번호는 6자리 이상이어야 합니다f")
+                setWaringView(waringShown: false, text: "비밀번호는 6자리 이상이어야 합니다")
                 passedSubject.send(false)
                 warningShownSubject.send(true)
             case .focused:


### PR DESCRIPTION
# Issue Number
🔒 Close #128 

## New features

- 회원가입 / 로그인 뷰로 이동 가능한 버튼 라벨 추가 UI 수정 완료
- 네비게이션 / 모달 뷰에 대한 동작 커스텀
- 일반 뷰: 로그인 → 회원가입 네비게이션 이동
- 모달: 로그인 → 회원가입, 회원가입 → 로그인: present하는 뷰 컨트롤러 접근, dismiss + 해당 뷰 모달 뷰로 호출
- 모달 → 레이아웃 viewWillAppear에서 다시 한 번 
- 키보드 → 모달인 경우 포함
- 회원가입 / 로그인 성공 시 → (1) 모달인 경우 회원가입 성공 시 로그인 뷰 띄우기, 로그인 성공 시 모달 dismiss (2). 일반 뷰인 경우 SplitVC에 해당 노티피케이션 주기 → 제 파트 아닙니다

- screenshot(optional)
![Simulator Screen Recording - iPad mini (6th generation) - 2022-10-22 at 23 21 47](https://user-images.githubusercontent.com/95460398/197344336-697dadfc-a761-42d4-bcc4-922f393778a9.gif)


## Review points

- write here

## Questions

- write here

## References

- write here 

## Checklist

- [x] Is the branch you are merging on correct?
- [x] Do you comply with coding conventions?
- [x] Are there any changes not related to PR?
- [x] Has my code been self-reviewed?
