### PR TITLE
Fix/Fix SplitView Navigation Control Logic/#124 #110

### DIFF
--- a/RollingPaper/RollingPaper.xcodeproj/project.pbxproj
+++ b/RollingPaper/RollingPaper.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		C5F6954A28FEDA3800365719 /* WrittenPaperViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F6954928FEDA3800365719 /* WrittenPaperViewController.swift */; };
 		C5F6954C28FEDCF700365719 /* UIButton+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F6954B28FEDCF700365719 /* UIButton+Extensions.swift */; };
 		CF1DEADE28F862720024EA1F /* SidebarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF1DEADD28F862720024EA1F /* SidebarViewModel.swift */; };
+		CFA10C97290585C7002B8653 /* Notification.Name+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFA10C96290585C7002B8653 /* Notification.Name+Extension.swift */; };
 		CFDA52C128F48D08006774E2 /* CategoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFDA52C028F48D08006774E2 /* CategoryModel.swift */; };
 		CFDA52C328F48D41006774E2 /* SplitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFDA52C228F48D41006774E2 /* SplitViewController.swift */; };
 		CFDA52C528F48E96006774E2 /* SidebarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFDA52C428F48E96006774E2 /* SidebarViewController.swift */; };
@@ -107,6 +108,7 @@
 		C5F6954928FEDA3800365719 /* WrittenPaperViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrittenPaperViewController.swift; sourceTree = "<group>"; };
 		C5F6954B28FEDCF700365719 /* UIButton+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+Extensions.swift"; sourceTree = "<group>"; };
 		CF1DEADD28F862720024EA1F /* SidebarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarViewModel.swift; sourceTree = "<group>"; };
+		CFA10C96290585C7002B8653 /* Notification.Name+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification.Name+Extension.swift"; sourceTree = "<group>"; };
 		CFDA52C028F48D08006774E2 /* CategoryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryModel.swift; sourceTree = "<group>"; };
 		CFDA52C228F48D41006774E2 /* SplitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitViewController.swift; sourceTree = "<group>"; };
 		CFDA52C428F48E96006774E2 /* SidebarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarViewController.swift; sourceTree = "<group>"; };
@@ -244,6 +246,7 @@
 				C5F6954B28FEDCF700365719 /* UIButton+Extensions.swift */,
 				D2CB508E28FD49E70065C2A9 /* UNUserNotificationCenter+Extensions.swift */,
 				C5B5853B29001AFF00454C75 /* UIImage+Extension.swift */,
+				CFA10C96290585C7002B8653 /* Notification.Name+Extension.swift */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -540,6 +543,7 @@
 				D22E4AC228EBFD7B001091DA /* FirestoreManager.swift in Sources */,
 				D251BDCB28ED32890094ECD9 /* UIColor+Extensions.swift in Sources */,
 				D2CB508F28FD49E70065C2A9 /* UNUserNotificationCenter+Extensions.swift in Sources */,
+				CFA10C97290585C7002B8653 /* Notification.Name+Extension.swift in Sources */,
 				D251BDBF28ED219D0094ECD9 /* PaperModel.swift in Sources */,
 				AFE8D6EE28F6E270005B1F45 /* CardViewModel.swift in Sources */,
 				C5B5853C29001AFF00454C75 /* UIImage+Extension.swift in Sources */,

--- a/RollingPaper/RollingPaper/Controllers/SettingScreenViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/SettingScreenViewController.swift
@@ -303,7 +303,11 @@ class SettingScreenViewController: UIViewController, UIImagePickerControllerDele
                 switch output {
                 case .signOutDidSucceed:
                     if let parentView = self.navigationController?.parent as? SplitViewController {
-                        parentView.didSelectCategory(CategoryModel(name: "설정", icon: ""))
+                        NotificationCenter.default.post(
+                            name: Notification.Name.viewChange,
+                            object: nil,
+                            userInfo: [NotificationViewKey.view: "설정"]
+                        )
                     }
                 case .userProfileChangeDidSuccess:
                     print("Output Received!")

--- a/RollingPaper/RollingPaper/Controllers/SidebarViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/SidebarViewController.swift
@@ -147,8 +147,10 @@ class SidebarViewController: UIViewController, UITableViewDataSource, UITableVie
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         let category = self.categories[indexPath.row]
-        NotificationCenter.default.post(name : Notification.Name.viewChange, object: nil, userInfo: [NotificationViewKey.view: category.name])
-        // self.delegate?.didSelectCategory(category)
+        NotificationCenter.default.post(
+            name: Notification.Name.viewChangeFromSidebar,
+            object: nil,
+            userInfo: [NotificationViewKey.view: category.name])
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {

--- a/RollingPaper/RollingPaper/Controllers/SidebarViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/SidebarViewController.swift
@@ -17,6 +17,7 @@ protocol SidebarViewControllerDelegate: AnyObject {
 class SidebarViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
     
     var delegate: SidebarViewControllerDelegate?
+    
     private var categories: [CategoryModel] = []
     private let viewModel = SidebarViewModel()
     private var cancellables = Set<AnyCancellable>()
@@ -146,7 +147,8 @@ class SidebarViewController: UIViewController, UITableViewDataSource, UITableVie
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         let category = self.categories[indexPath.row]
-        self.delegate?.didSelectCategory(category)
+        NotificationCenter.default.post(name : Notification.Name.viewChange, object: nil, userInfo: [NotificationViewKey.view: category.name])
+        // self.delegate?.didSelectCategory(category)
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {

--- a/RollingPaper/RollingPaper/Controllers/SplitViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/SplitViewController.swift
@@ -64,7 +64,8 @@ class SplitViewController: UISplitViewController, UISplitViewControllerDelegate 
             self.viewControllers[1] = paperTemplateSelectViewController
         case "페이퍼 보관함":
             if currentSecondaryView == "페이퍼 보관함" {
-                self.viewControllers[1] = UINavigationController(rootViewController: PaperStorageViewController())
+                self.paperStorageViewController = UINavigationController(rootViewController: PaperStorageViewController())
+                self.viewControllers[1] = paperStorageViewController
             } else {
                 self.viewControllers[1] = paperStorageViewController
             }

--- a/RollingPaper/RollingPaper/Controllers/SplitViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/SplitViewController.swift
@@ -13,7 +13,44 @@ class SplitViewController: UISplitViewController, UISplitViewControllerDelegate,
     
     private let splitViewManager = SplitViewManager.shared
     private let input: PassthroughSubject<SplitViewManager.Input, Never> = .init()
+    private var sidebarViewController: SidebarViewController!
+    // private var templateViewController: PaperTemplateSelectViewController!
+    // private var storageViewController: PaperStorageViewController!
+    // private var mainViewController: MainViewController!
+    // private var settingViewController: SettingScreenViewController!
+    private var current = "페이퍼 템플릿"
+    private var paperTemplateSelectViewController: UINavigationController!
+    private var paperStorageViewController: UINavigationController!
+    private var settingScreenViewController: UINavigationController!
     
+    var sideBarCategories: [CategoryModel] = [
+        CategoryModel(name: "페이퍼 템플릿", icon: "doc.on.doc"),
+        CategoryModel(name: "페이퍼 보관함", icon: "folder"),
+        CategoryModel(name: "설정", icon: "gearshape")
+    ]
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        NotificationCenter.default.addObserver(self, selector: #selector(changeSecondaryView(noitificaiton:)), name: Notification.Name.viewChange, object: nil)
+        self.preferredDisplayMode = UISplitViewController.DisplayMode.oneBesideSecondary
+        self.presentsWithGesture = true
+        self.loadViewControllers()
+        self.sidebarViewController.show(categories: self.sideBarCategories)
+        self.preferredPrimaryColumnWidthFraction = 0.25
+        delegate = self
+        splitViewManager.transform(input: input.eraseToAnyPublisher())
+    }
+    
+    private func loadViewControllers() {
+        self.sidebarViewController.delegate = self
+        self.sidebarViewController = SidebarViewController()
+        self.paperTemplateSelectViewController = UINavigationController(rootViewController: PaperTemplateSelectViewController())
+        self.paperStorageViewController = UINavigationController(rootViewController: PaperStorageViewController())
+        self.settingScreenViewController = UINavigationController(rootViewController: SettingScreenViewController())
+        let sidebar = UINavigationController(rootViewController: self.sidebarViewController)
+        self.viewControllers = [sidebar, paperTemplateSelectViewController]
+    }
+    /*
     func didSelectCategory(_ category: CategoryModel) {
         let templateViewController = UINavigationController(rootViewController: self.templateViewController)
         let paperStorageViewController = UINavigationController(rootViewController: self.storageViewController)
@@ -41,28 +78,23 @@ class SplitViewController: UISplitViewController, UISplitViewControllerDelegate,
             break
         }
     }
-    
-    var sideBarCategories: [CategoryModel] = [
-        CategoryModel(name: "페이퍼 템플릿", icon: "doc.on.doc"),
-        CategoryModel(name: "페이퍼 보관함", icon: "folder"),
-        CategoryModel(name: "설정", icon: "gearshape")
-    ]
-    private var sidebarViewController: SidebarViewController!
-    private var templateViewController: PaperTemplateSelectViewController!
-    private var storageViewController: PaperStorageViewController!
-    private var mainViewController: MainViewController!
-    private var settingViewController: SettingScreenViewController!
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        self.preferredDisplayMode = UISplitViewController.DisplayMode.oneBesideSecondary
-        self.presentsWithGesture = true
-        self.loadViewControllers()
-        self.sidebarViewController.show(categories: self.sideBarCategories)
-        self.preferredPrimaryColumnWidthFraction = 0.25
-        
-        delegate = self
-        splitViewManager.transform(input: input.eraseToAnyPublisher())
+    */
+    @objc func changeSecondaryView(noitificaiton: Notification) {
+        guard let object = noitificaiton.userInfo?[NotificationViewKey.view] as? String else { return }
+        if self.current == object {
+            return
+        }
+        switch object {
+        case "페이퍼 템플릿":
+            self.viewControllers[1] = paperTemplateSelectViewController
+        case "페이퍼 보관함":
+            self.viewControllers[1] = paperStorageViewController
+        case "설정":
+            self.viewControllers[1] = settingScreenViewController
+        default :
+            break
+        }
+        self.current = object
     }
     
     func splitViewController(_ svc: UISplitViewController, willChangeTo displayMode: UISplitViewController.DisplayMode) {
@@ -79,17 +111,5 @@ class SplitViewController: UISplitViewController, UISplitViewControllerDelegate,
     
     func primaryViewController(forExpanding splitViewController: UISplitViewController) -> UIViewController? {
         return self.viewControllers.last
-    }
-    
-    private func loadViewControllers() {
-        self.sidebarViewController = SidebarViewController()
-        self.templateViewController = PaperTemplateSelectViewController()
-        self.storageViewController = PaperStorageViewController()
-        self.mainViewController = MainViewController()
-        self.settingViewController = SettingScreenViewController()
-        self.sidebarViewController.delegate = self
-        let sidebar = UINavigationController(rootViewController: self.sidebarViewController)
-        let templateViewController = UINavigationController(rootViewController: self.templateViewController)
-        self.viewControllers = [sidebar, templateViewController]
     }
 }

--- a/RollingPaper/RollingPaper/Controllers/SplitViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/SplitViewController.swift
@@ -9,15 +9,11 @@ import UIKit
 import Combine
 import CombineCocoa
 
-class SplitViewController: UISplitViewController, UISplitViewControllerDelegate, SidebarViewControllerDelegate {
+class SplitViewController: UISplitViewController, UISplitViewControllerDelegate {
     
     private let splitViewManager = SplitViewManager.shared
     private let input: PassthroughSubject<SplitViewManager.Input, Never> = .init()
     private var sidebarViewController: SidebarViewController!
-    // private var templateViewController: PaperTemplateSelectViewController!
-    // private var storageViewController: PaperStorageViewController!
-    // private var mainViewController: MainViewController!
-    // private var settingViewController: SettingScreenViewController!
     private var current = "페이퍼 템플릿"
     private var paperTemplateSelectViewController: UINavigationController!
     private var paperStorageViewController: UINavigationController!
@@ -31,7 +27,18 @@ class SplitViewController: UISplitViewController, UISplitViewControllerDelegate,
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        NotificationCenter.default.addObserver(self, selector: #selector(changeSecondaryView(noitificaiton:)), name: Notification.Name.viewChange, object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(changeSecondaryView(noitificaiton:)),
+            name: Notification.Name.viewChange,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(changeSecondaryViewFromSidebar(noitificaiton:)),
+            name: Notification.Name.viewChangeFromSidebar,
+            object: nil
+        )
         self.preferredDisplayMode = UISplitViewController.DisplayMode.oneBesideSecondary
         self.presentsWithGesture = true
         self.loadViewControllers()
@@ -42,7 +49,7 @@ class SplitViewController: UISplitViewController, UISplitViewControllerDelegate,
     }
     
     private func loadViewControllers() {
-        self.sidebarViewController.delegate = self
+        // self.sidebarViewController.delegate = self
         self.sidebarViewController = SidebarViewController()
         self.paperTemplateSelectViewController = UINavigationController(rootViewController: PaperTemplateSelectViewController())
         self.paperStorageViewController = UINavigationController(rootViewController: PaperStorageViewController())
@@ -50,36 +57,23 @@ class SplitViewController: UISplitViewController, UISplitViewControllerDelegate,
         let sidebar = UINavigationController(rootViewController: self.sidebarViewController)
         self.viewControllers = [sidebar, paperTemplateSelectViewController]
     }
-    /*
-    func didSelectCategory(_ category: CategoryModel) {
-        let templateViewController = UINavigationController(rootViewController: self.templateViewController)
-        let paperStorageViewController = UINavigationController(rootViewController: self.storageViewController)
-        let settingScreenViewController = UINavigationController(rootViewController: self.settingViewController)
-        
-        switch category.name {
+    
+    @objc func changeSecondaryView(noitificaiton: Notification) {
+        guard let object = noitificaiton.userInfo?[NotificationViewKey.view] as? String else { return }
+        switch object {
         case "페이퍼 템플릿":
-            if !(self.viewControllers[1] is PaperTemplateSelectViewController) {
-                self.viewControllers[1] = templateViewController
-            }
+            self.viewControllers[1] = paperTemplateSelectViewController
         case "페이퍼 보관함":
-            if !(self.viewControllers[1] is PaperStorageViewController) {
-                self.viewControllers[1] = paperStorageViewController
-            }
+            self.viewControllers[1] = UINavigationController(rootViewController: PaperStorageViewController())
         case "설정":
-            if !(self.viewControllers[1] is SettingScreenViewController) {
-                if let currentUserEmail = UserDefaults.standard.value(forKey: "currentUserEmail") as? String {
-                    print(currentUserEmail)
-                    self.viewControllers[1] = settingScreenViewController
-                } else {
-                    self.viewControllers[1] = UINavigationController(rootViewController: SignInViewController())
-                }
-            }
-        default:
+            self.viewControllers[1] = settingScreenViewController
+        default :
             break
         }
+        self.current = object
     }
-    */
-    @objc func changeSecondaryView(noitificaiton: Notification) {
+    
+    @objc func changeSecondaryViewFromSidebar(noitificaiton: Notification) {
         guard let object = noitificaiton.userInfo?[NotificationViewKey.view] as? String else { return }
         if self.current == object {
             return

--- a/RollingPaper/RollingPaper/Controllers/SplitViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/SplitViewController.swift
@@ -14,7 +14,7 @@ class SplitViewController: UISplitViewController, UISplitViewControllerDelegate 
     private let splitViewManager = SplitViewManager.shared
     private let input: PassthroughSubject<SplitViewManager.Input, Never> = .init()
     private var sidebarViewController: SidebarViewController!
-    private var current = "페이퍼 템플릿"
+    private var currentSecondaryView = "페이퍼 템플릿"
     private var paperTemplateSelectViewController: UINavigationController!
     private var paperStorageViewController: UINavigationController!
     private var settingScreenViewController: UINavigationController!
@@ -49,7 +49,6 @@ class SplitViewController: UISplitViewController, UISplitViewControllerDelegate 
     }
     
     private func loadViewControllers() {
-        // self.sidebarViewController.delegate = self
         self.sidebarViewController = SidebarViewController()
         self.paperTemplateSelectViewController = UINavigationController(rootViewController: PaperTemplateSelectViewController())
         self.paperStorageViewController = UINavigationController(rootViewController: PaperStorageViewController())
@@ -64,18 +63,22 @@ class SplitViewController: UISplitViewController, UISplitViewControllerDelegate 
         case "페이퍼 템플릿":
             self.viewControllers[1] = paperTemplateSelectViewController
         case "페이퍼 보관함":
-            self.viewControllers[1] = UINavigationController(rootViewController: PaperStorageViewController())
+            if currentSecondaryView == "페이퍼 보관함" {
+                self.viewControllers[1] = UINavigationController(rootViewController: PaperStorageViewController())
+            } else {
+                self.viewControllers[1] = paperStorageViewController
+            }
         case "설정":
             self.viewControllers[1] = settingScreenViewController
         default :
             break
         }
-        self.current = object
+        self.currentSecondaryView = object
     }
     
     @objc func changeSecondaryViewFromSidebar(noitificaiton: Notification) {
         guard let object = noitificaiton.userInfo?[NotificationViewKey.view] as? String else { return }
-        if self.current == object {
+        if self.currentSecondaryView == object {
             return
         }
         switch object {
@@ -88,7 +91,7 @@ class SplitViewController: UISplitViewController, UISplitViewControllerDelegate 
         default :
             break
         }
-        self.current = object
+        self.currentSecondaryView = object
     }
     
     func splitViewController(_ svc: UISplitViewController, willChangeTo displayMode: UISplitViewController.DisplayMode) {

--- a/RollingPaper/RollingPaper/Controllers/WrittenPaperViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/WrittenPaperViewController.swift
@@ -138,23 +138,12 @@ class WrittenPaperViewController: UIViewController {
         navigationItem.leftBarButtonItem = firstBarButton
     }
     
-    func moveToPaperStorageView() {
-        if
-            let currentVC = self.navigationController?.viewControllers.filter({ $0 is PaperTemplateSelectViewController }).first,
-            let splitVC = currentVC.parent?.parent as? SplitViewController {
-            splitVC.didSelectCategory(CategoryModel(name: "페이퍼 보관함", icon: "folder"))
-            if viewModel.paperFrom == .fromLocal {
-                viewModel.localDatabaseManager.resetPaper()
-            }
-        } else if
-            let currentVC = self.navigationController?.viewControllers.filter({ $0 is PaperStorageViewController }).first,
-            let splitVC = currentVC.parent?.parent as? SplitViewController {
-            splitVC.didSelectCategory(CategoryModel(name: "페이퍼 보관함", icon: "folder"))
-            if viewModel.paperFrom == .fromLocal {
-                viewModel.localDatabaseManager.resetPaper()
-            }
-            
-        }
+    private func moveToPaperStorageView() {
+        NotificationCenter.default.post(
+            name: Notification.Name.viewChange,
+            object: nil,
+            userInfo: [NotificationViewKey.view: "페이퍼 보관함"]
+        )
     }
     
     func moveToCardRootView() {

--- a/RollingPaper/RollingPaper/Resources/Notification.Name+Extension.swift
+++ b/RollingPaper/RollingPaper/Resources/Notification.Name+Extension.swift
@@ -1,0 +1,16 @@
+//
+//  Notification.Name+Extension.swift
+//  RollingPaper
+//
+//  Created by Kelly Chui on 2022/10/23.
+//
+
+import Foundation
+
+extension Notification.Name {
+    static let viewChange = Notification.Name("viewChange")
+}
+
+enum NotificationViewKey {
+    case view
+}

--- a/RollingPaper/RollingPaper/Resources/Notification.Name+Extension.swift
+++ b/RollingPaper/RollingPaper/Resources/Notification.Name+Extension.swift
@@ -9,6 +9,7 @@ import Foundation
 
 extension Notification.Name {
     static let viewChange = Notification.Name("viewChange")
+    static let viewChangeFromSidebar = Notification.Name("ViewChangeFromSidebar")
 }
 
 enum NotificationViewKey {


### PR DESCRIPTION
# Issue Number
🔒 Close #110 
🔒 Close #124 

## New features

- write here
- Navigation Control 방식을 NotificationCenter로 변경했습니다.
- 이제 더이상 여분의 View가 생기지 않습니다.
- screenshot(optional)
![Simulator Screen Recording - iPad Air (5th generation) - 2022-10-24 at 23 22 26](https://user-images.githubusercontent.com/57012734/197549551-b69fd7d5-817c-4551-963a-6f1768f6d2bf.gif)

## Questions

- write here
- 페이퍼 내부 카드들 보기 뷰에서 Sidebar가 접히고 열리는 부분이 좀 어색합니다. 이부분도 Notification Center로 SplitView에서 한번에 처리하는 방식이 좋을까요?

## Checklist

- [x] Is the branch you are merging on correct?
- [x] Do you comply with coding conventions?
- [x] Are there any changes not related to PR?
- [x] Has my code been self-reviewed?
