### PR TITLE
Feature/Add Alert in CardRootView Back Button/#153

### DIFF
--- a/RollingPaper/RollingPaper/Controllers/CardRootViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/CardRootViewController.swift
@@ -199,9 +199,19 @@ class CardRootViewController: UIViewController {
     }
     
     @objc func cancelBtnPressed(_ gesture: UITapGestureRecognizer) {
-        print("cancelBtnPressed")
-        self.navigationController?.popViewController(animated: true)
-    }
+         print("cancelBtnPressed")
+         let alert = UIAlertController(title: "잠깐! 작성중인 카드가 사라져요.", message: "페이퍼로 돌아가시겠습니까?", preferredStyle: .alert)
+     
+         alert.addAction(UIAlertAction(title: "취소", style: .destructive, handler: { (_: UIAlertAction!) in
+             alert.dismiss(animated: true, completion: nil)
+            }))
+         
+         alert.addAction(UIAlertAction(title: "확인", style: .default, handler: { (_: UIAlertAction!) in
+             self.navigationController?.popViewController(animated: true)
+            }))
+         
+         present(alert, animated: true)
+     }
 }
 
 extension UIImage {


### PR DESCRIPTION
# Issue Number
🔒 Close #153 

## New features
- 카드제작 화면에서, 뒤로가기 버튼을 눌렀을때, 알림창 뜸.
- 카드 데이터가 사라진다는 것을 한번더 확인 시켜 준다.

## Review points
![simulator_screenshot_68555178-84B7-4F84-93C2-EF0F3E19758E](https://user-images.githubusercontent.com/40324511/197907963-aa9f25d4-b9bb-4aa2-840f-ce9e944458ba.png)


- write here

## Questions

- write here

## References

- write here 

## Checklist

- [ ] Is the branch you are merging on correct?
- [ ] Do you comply with coding conventions?
- [ ] Are there any changes not related to PR?
- [ ] Has my code been self-reviewed?
