### PR TITLE
Feature/authmanager userprofileimage/#165

### DIFF
--- a/RollingPaper/RollingPaper/Controllers/SidebarViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/SidebarViewController.swift
@@ -97,8 +97,19 @@ class SidebarViewController: UIViewController, UITableViewDataSource, UITableVie
 //                    self?.convertURL(from: userModel.profileUrl)
                     self?.userName.text = userModel.name
                 } else {
-                    self?.userPhoto.image = UIImage(systemName: "person.circle")
+//                    self?.userPhoto.image = UIImage(systemName: "person.circle")
                     self?.userName.text = "Guest"
+                }
+            }
+            .store(in: &cancellables)
+        viewModel
+            .currentPhotoSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] image in
+                if let image = image {
+                    self?.userPhoto.image = image
+                } else {
+                    self?.userPhoto.image = UIImage(systemName: "person.circle")
                 }
             }
             .store(in: &cancellables)

--- a/RollingPaper/RollingPaper/ViewModels/SidebarViewModel.swift
+++ b/RollingPaper/RollingPaper/ViewModels/SidebarViewModel.swift
@@ -7,12 +7,14 @@
 
 import Foundation
 import Combine
+import UIKit
 
 final class SidebarViewModel {
 
     private let authManager: AuthManager
     var cancellables = Set<AnyCancellable>()
     let currentUserSubject = PassthroughSubject<UserModel?, Never>()
+    let currentPhotoSubject: CurrentValueSubject<UIImage?, Never> = .init(UIImage(systemName: "person.circle"))
     
     init(authManager: AuthManager = FirebaseAuthManager.shared) {
         self.authManager = authManager
@@ -26,6 +28,16 @@ final class SidebarViewModel {
                 print("Im sending data!")
                 print("Im nil ?: \(userProfile == nil)")
                 self?.currentUserSubject.send(userProfile)
+            }
+            .store(in: &cancellables)
+        authManager
+            .userProfileImageSubject
+            .sink { [weak self] image in
+                if let image = image {
+                    self?.currentPhotoSubject.send(image)
+                } else {
+                    self?.currentPhotoSubject.send(UIImage(systemName: "person.circle"))
+                }
             }
             .store(in: &cancellables)
     }


### PR DESCRIPTION
# Issue Number
🔒 Close #165

## New features

사진 다운로드 기능을 AuthManager 내에 할당합니다
캐시에 있으면 캐시, 없으면 로컬 → 서버로 찾고 다운로드받은 뒤 캐시에 저장합니다
세팅 뷰모델, 사이드바 뷰모델에 해당 이미지 퍼블리셔를 구독하고 뷰 컨트롤러에서 해당 퍼블리셔의 데이터를 사용합니다

![Simulator Screen Shot - iPad mini (6th generation) - 2022-10-26 at 12 14 13](https://user-images.githubusercontent.com/95460398/197926042-4ebc2a87-5ac1-4583-a424-59481e861a9a.png)

- screenshot(optional)

## Review points

- write here

## Questions

- write here

## References

- write here 

## Checklist

- [ ] Is the branch you are merging on correct?
- [ ] Do you comply with coding conventions?
- [ ] Are there any changes not related to PR?
- [ ] Has my code been self-reviewed?
