### PR TITLE
Fix/index error in paper storage/#181

### DIFF
--- a/RollingPaper/RollingPaper/Controllers/PaperStorageViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/PaperStorageViewController.swift
@@ -19,7 +19,7 @@ private class Length {
     static let sectionRightMargin: CGFloat = 36
     static let sectionLeftMargin: CGFloat = 36
     
-    static var openedPaperThumbnailWidth: CGFloat = (UIScreen.main.bounds.width*0.75-(sectionLeftMargin+sectionRightMargin+openedCellHorizontalSpace+1))/2 // 반응형
+    static var openedPaperThumbnailWidth: CGFloat = (UIScreen.main.bounds.width*0.75-(sectionLeftMargin+sectionRightMargin+openedCellHorizontalSpace+2))/2 // 반응형
     static let openedPaperThumbnailHeight: CGFloat = openedPaperThumbnailWidth*0.33
     static let openedPaperTitleBottomMargin: CGFloat = 16
     static let openedPaperTitleRightMargin: CGFloat = 16
@@ -118,7 +118,7 @@ class PaperStorageViewController: UIViewController {
     // 스플릿뷰 열고닫음에 따라 뷰 업데이트하기
     private func updateLayout() {
         let multiplyVal = splitViewIsOpened ? 0.75 : 1.0
-        Length.openedPaperThumbnailWidth = (UIScreen.main.bounds.width*multiplyVal-(Length.sectionLeftMargin+Length.sectionRightMargin+Length.openedCellHorizontalSpace+1))/2
+        Length.openedPaperThumbnailWidth = (UIScreen.main.bounds.width*multiplyVal-(Length.sectionLeftMargin+Length.sectionRightMargin+Length.openedCellHorizontalSpace+2))/2
         Length.closedPaperThumbnailWidth = (UIScreen.main.bounds.width*multiplyVal-(Length.sectionLeftMargin+Length.sectionRightMargin))
         paperCollectionView?.reloadData()
     }


### PR DESCRIPTION
# Issue Number
🔒 Close #181 

## New features
- 에러가 매번 일어나는게 아니라 가끔만 일어나다 말다 해서 사실 완벽히 고쳐진지는 모르겠습니다.
- 바동기로 동시에 너무 많이 연산이 실행되서 발생하는 오류 같아서, 결론적으로 고친 것은 연산을 최소화한 것입니다.
     - 그동안 코드를 computed property로 썼더니 쓸데없이 연산을 많이하길레 함수로 빼놨습니다.
     - 뷰 전환시에 스플릿뷰가 닫힐 때 일어나는 이벤트들도 실행하고 있길레, 실행 되지 않도록 했습니다.
- 가끔 어떤 기기에서는 셀이 두열로 안보여서 셀 크기를 정말 아주 살짝 작게 해줬습니다.

## Checklist
- [X] Is the branch you are merging on correct?
- [X] Do you comply with coding conventions?
- [X] Are there any changes not related to PR?
- [X] Has my code been self-reviewed?
