### PR TITLE
Fix/fix presenting link share sheet logic/#197

### DIFF
--- a/RollingPaper/RollingPaper/Controllers/WrittenPaperViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/WrittenPaperViewController.swift
@@ -17,8 +17,9 @@ class WrittenPaperViewController: UIViewController {
     
     private let authManager: AuthManager = FirebaseAuthManager.shared
     private let currentUserSubject = PassthroughSubject<UserModel?, Never>()
-    //    var urlToShare: [URL]?
     private var cancellables = Set<AnyCancellable>()
+    
+    private var paperLinkBtnIsPressed:Bool = false
     
     lazy private var titleLabel: BasePaddingLabel = {
         let titleLabel = BasePaddingLabel()
@@ -175,19 +176,16 @@ class WrittenPaperViewController: UIViewController {
         paperLinkBtn.addAction(UIAction(handler: {_ in
             if self.viewModel.isSameCurrentUserAndCreator {
                 self.makeCurrentPaperLink()
-                if self.viewModel.currentPaper?.linkUrl == nil {
-                    self.viewModel
-                        .currentPaperPublisher
-                        .receive(on: DispatchQueue.main)
-                        .sink{ [weak self] paperModel in
-                            if self?.viewModel.isTitleChanged == false {
-                                self?.presentShareSheet(paperLinkBtn)
-                            }}
-                        .store(in: &self.cancellables)
-                } else {
-                    if self.viewModel.isTitleChanged == false {
-                        self.presentShareSheet(paperLinkBtn)
-                    }}
+                self.paperLinkBtnIsPressed = true
+                self.viewModel
+                    .currentPaperPublisher
+                    .receive(on: DispatchQueue.main)
+                    .sink{ [weak self] paperModel in
+                        if self?.paperLinkBtnIsPressed == true {
+                            self?.presentShareSheet(paperLinkBtn)}
+                    }
+                    .store(in: &self.cancellables)
+                
             } else {
                 self.presentSignUpModal(paperLinkBtn)
             }
@@ -270,6 +268,7 @@ class WrittenPaperViewController: UIViewController {
         let popover = activityViewController.popoverPresentationController
         popover?.sourceView = sender
         self.present(activityViewController, animated: true)
+        self.paperLinkBtnIsPressed = false
     }
     
     func setPopOverView(_ sender: UIButton) {

--- a/RollingPaper/RollingPaper/Controllers/WrittenPaperViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/WrittenPaperViewController.swift
@@ -175,15 +175,19 @@ class WrittenPaperViewController: UIViewController {
         paperLinkBtn.addAction(UIAction(handler: {_ in
             if self.viewModel.isSameCurrentUserAndCreator {
                 self.makeCurrentPaperLink()
-                self.viewModel
-                    .currentPaperPublisher
-                    .receive(on: DispatchQueue.main)
-                    .sink{ [weak self] paperModel in
-                        if paperModel?.linkUrl != nil {
-                            self?.presentShareSheet(paperLinkBtn)
-                        }
-                    }
-                    .store(in: &self.cancellables)
+                if self.viewModel.currentPaper?.linkUrl == nil {
+                    self.viewModel
+                        .currentPaperPublisher
+                        .receive(on: DispatchQueue.main)
+                        .sink{ [weak self] paperModel in
+                            if self?.viewModel.isTitleChanged == false {
+                                self?.presentShareSheet(paperLinkBtn)
+                            }}
+                        .store(in: &self.cancellables)
+                } else {
+                    if self.viewModel.isTitleChanged == false {
+                        self.presentShareSheet(paperLinkBtn)
+                    }}
             } else {
                 self.presentSignUpModal(paperLinkBtn)
             }

--- a/RollingPaper/RollingPaper/ViewModels/WrittenPaperViewModel.swift
+++ b/RollingPaper/RollingPaper/ViewModels/WrittenPaperViewModel.swift
@@ -29,6 +29,7 @@ class WrittenPaperViewModel {
     private var paperID: String = ""
     private var paperTemplate: TemplateModel?
     private var paperTitle: String?
+    var isTitleChanged: Bool = false
     private var timeRemaing: Date?
     
     var isPaperLinkMade: Bool = false
@@ -83,6 +84,7 @@ class WrittenPaperViewModel {
     
     func changePaperTitle(input: String, from paperFrom: DataSource) {
         currentPaper?.title = input
+        isTitleChanged = true
         guard let paper = currentPaper else { return }
         switch paperFrom {
         case .fromLocal:


### PR DESCRIPTION
# Issue Number
🔒 Close #197

## New features
페이퍼의 링크가 만들어진 후 페이퍼 타이틀을 수정하면 공유 시트가 버튼을 누르지 않아도 자동으로 뜨는 이슈에 대한 fix

## Review points

- write here

## Questions

- write here

## References

- write here 

## Checklist

- [ ] Is the branch you are merging on correct?
- [ ] Do you comply with coding conventions?
- [ ] Are there any changes not related to PR?
- [ ] Has my code been self-reviewed?
