### PR TITLE
Feature/make pager without external library/#201

### DIFF
--- a/RollingPaper/RollingPaper/Controllers/MagnifiedCardViewController.swift
+++ b/RollingPaper/RollingPaper/Controllers/MagnifiedCardViewController.swift
@@ -10,45 +10,58 @@ import UIKit
 import SnapKit
 
 class MagnifiedCardViewController: UIViewController {
-    var cardContentURLString: String?
-    var magnifiedCardImage = UIImageView()
     var closeBtn: UIButton = UIButton()
+    var scrollView = UIScrollView()
+    var images = [UIImage?]()
+    var selectedIndex = 0
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.isOpaque = false
-        view.backgroundColor = .clear
-        self.closeBtn.addTarget(self, action: #selector(closeAction), for: UIControl.Event.touchUpInside)
-        magnifiedCardImage.backgroundColor = .clear
-        magnifiedCardImage.layer.cornerRadius = 50
-        magnifiedCardImage.clipsToBounds = true
-        view.addSubview(magnifiedCardImage)
-        view.addSubview(closeBtn)
-        setImageSize()
-        setBtnSize()
+        setView()
+        setPagerView()
     }
-    
+    // 현재 창 닫기
     @objc func closeAction() {
         dismiss(animated: true)
     }
-    
-    func setBtnSize() {
-        closeBtn.snp.makeConstraints { make in
-            make.top.equalTo(self.view).offset(0)
-            make.leading.equalTo(self.view).offset(0)
-            make.bottom.equalTo(self.view).offset(0)
-            make.trailing.equalTo(self.view).offset(0)
+    // 뷰 설정하기
+    func setView() {
+        view.isOpaque = false
+        view.backgroundColor = .clear
+        view.addSubview(closeBtn)
+        view.addSubview(scrollView)
+
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(closeAction))
+        view.addGestureRecognizer(tapGesture)
+    }
+    // 페이저 설정하기
+    func setPagerView() {
+        let contentWidth = view.bounds.width * 0.75
+        let contentHeight = view.bounds.width * 0.75 * 0.75
+        
+        scrollView.snp.makeConstraints({ make in
+            make.width.equalTo(contentWidth)
+            make.height.equalTo(contentHeight)
+            make.centerX.equalTo(view)
+            make.centerY.equalTo(view)
+        })
+        scrollView.contentSize = CGSize(width: contentWidth * CGFloat(images.count), height: contentHeight)
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.isScrollEnabled = true
+        scrollView.isPagingEnabled = true
+        scrollView.bounces = false
+        scrollView.contentOffset = CGPoint(x: contentWidth*CGFloat(selectedIndex), y: 0)
+        
+        for (index, image) in images.enumerated() {
+            let imageView = UIImageView(image: image)
+            scrollView.addSubview(imageView)
+            imageView.snp.makeConstraints({ make in
+                make.centerY.equalToSuperview()
+                make.centerX.equalToSuperview().offset(contentWidth*CGFloat(index))
+                make.width.equalTo(contentWidth)
+                make.height.equalTo(contentHeight)
+            })
         }
     }
-    
-    func setImageSize() {
-        magnifiedCardImage.snp.makeConstraints { make in
-            make.width.equalTo(self.view.bounds.width * 0.75)
-            make.height.equalTo(self.view.bounds.width * 0.75 * 0.75)
-            make.leading.equalTo(self.view.snp.leading).offset(self.view.bounds.width * 0.1)
-            make.trailing.equalTo(self.view.snp.trailing).offset(-(self.view.bounds.width * 0.1))
-            make.centerX.equalTo(self.view)
-            make.centerY.equalTo(self.view)
-        }
-    } //확대된 카드의 사이즈 결정
 }


### PR DESCRIPTION
# Issue Number
🔒 Close #201 

## New features
- 카드를 선택하면 슬라이드 형태로 보여줍니다.
- 나머지 카드들도 옆으로 슬라이드 하며 볼 수 있습니다.
- 짧게 터치하면 창을 닫을 수 있습니다.

![Simulator Screen Recording - iPad mini (6th generation) - 2022-11-04 at 15 53 57](https://user-images.githubusercontent.com/72330884/199910712-43f7f3be-1ffa-4853-a454-3a59785ba188.gif)

## Questions
- 디자인 없이 일단 임의로 해본것이어서 Merge를 할지는 다같이 보고 결정해야할듯합니다.
- 코드는 나중에 복붙하면 되니 이거 Merge는 엄청 후순위로 밀어도 됩니다.
- 현재는 카드 이미지를 전부 다운받고 전부 스크롤뷰에 미리 집어넣어서 보여주는 형태여서, 이 방식으로는 나중에 카드가 많아지면 스크롤뷰를 띄워주는 시간이 오래 걸릴듯합니다.
- 사이먼뷰쪽이 어느정도 리팩터링되면, 이 부분도 비동기 처리로 바꾸는 방식을 고려해보겠습니다. (로딩된 카드만 보여주고 안된 카드는 로딩중 이미지 띄워주기)

## Checklist

- [X] Is the branch you are merging on correct?
- [X] Do you comply with coding conventions?
- [X] Are there any changes not related to PR?
- [X] Has my code been self-reviewed?
