### PR TITLE
Feature/change sidebar view/#230

### DIFF
--- a/RollingPaper/RollingPaper.xcodeproj/project.pbxproj
+++ b/RollingPaper/RollingPaper.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		C5F26FE729183F050060109B /* TimerOfPaperViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F26FE629183F050060109B /* TimerOfPaperViewController.swift */; };
 		C5F6954A28FEDA3800365719 /* WrittenPaperViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F6954928FEDA3800365719 /* WrittenPaperViewController.swift */; };
 		C5F6954C28FEDCF700365719 /* UIButton+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F6954B28FEDCF700365719 /* UIButton+Extensions.swift */; };
+		CF0AAF3D291BC4FB000559D6 /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0AAF3C291BC4FB000559D6 /* File.swift */; };
 		CF1DEADE28F862720024EA1F /* SidebarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF1DEADD28F862720024EA1F /* SidebarViewModel.swift */; };
 		CFA10C97290585C7002B8653 /* Notification.Name+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFA10C96290585C7002B8653 /* Notification.Name+Extension.swift */; };
 		CFDA52C128F48D08006774E2 /* CategoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFDA52C028F48D08006774E2 /* CategoryModel.swift */; };
@@ -112,6 +113,7 @@
 		C5F26FE629183F050060109B /* TimerOfPaperViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerOfPaperViewController.swift; sourceTree = "<group>"; };
 		C5F6954928FEDA3800365719 /* WrittenPaperViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrittenPaperViewController.swift; sourceTree = "<group>"; };
 		C5F6954B28FEDCF700365719 /* UIButton+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+Extensions.swift"; sourceTree = "<group>"; };
+		CF0AAF3C291BC4FB000559D6 /* File.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = File.swift; sourceTree = "<group>"; };
 		CF1DEADD28F862720024EA1F /* SidebarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarViewModel.swift; sourceTree = "<group>"; };
 		CFA10C96290585C7002B8653 /* Notification.Name+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification.Name+Extension.swift"; sourceTree = "<group>"; };
 		CFDA52C028F48D08006774E2 /* CategoryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryModel.swift; sourceTree = "<group>"; };
@@ -328,6 +330,7 @@
 			isa = PBXGroup;
 			children = (
 				CFDA52C428F48E96006774E2 /* SidebarViewController.swift */,
+				CF0AAF3C291BC4FB000559D6 /* File.swift */,
 			);
 			path = Sidebar;
 			sourceTree = "<group>";
@@ -674,6 +677,7 @@
 				D2B6308028EE870D008365CB /* UIControl+Extensions.swift in Sources */,
 				C5F6954C28FEDCF700365719 /* UIButton+Extensions.swift in Sources */,
 				D2B6308E28F16493008365CB /* SignUpTextField.swift in Sources */,
+				CF0AAF3D291BC4FB000559D6 /* File.swift in Sources */,
 				AF6FEE3C2902E2E400E44E7D /* CameraCustomPicker.swift in Sources */,
 				D22E4AC428EBFD91001091DA /* SignInViewController.swift in Sources */,
 				D251BDC928ED2A310094ECD9 /* TemplateEnum.swift in Sources */,

--- a/RollingPaper/RollingPaper.xcodeproj/project.pbxproj
+++ b/RollingPaper/RollingPaper.xcodeproj/project.pbxproj
@@ -33,7 +33,6 @@
 		C5F26FE729183F050060109B /* TimerOfPaperViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F26FE629183F050060109B /* TimerOfPaperViewController.swift */; };
 		C5F6954A28FEDA3800365719 /* WrittenPaperViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F6954928FEDA3800365719 /* WrittenPaperViewController.swift */; };
 		C5F6954C28FEDCF700365719 /* UIButton+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F6954B28FEDCF700365719 /* UIButton+Extensions.swift */; };
-		CF0AAF3D291BC4FB000559D6 /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0AAF3C291BC4FB000559D6 /* File.swift */; };
 		CF1DEADE28F862720024EA1F /* SidebarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF1DEADD28F862720024EA1F /* SidebarViewModel.swift */; };
 		CFA10C97290585C7002B8653 /* Notification.Name+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFA10C96290585C7002B8653 /* Notification.Name+Extension.swift */; };
 		CFDA52C128F48D08006774E2 /* CategoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFDA52C028F48D08006774E2 /* CategoryModel.swift */; };
@@ -113,7 +112,6 @@
 		C5F26FE629183F050060109B /* TimerOfPaperViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerOfPaperViewController.swift; sourceTree = "<group>"; };
 		C5F6954928FEDA3800365719 /* WrittenPaperViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WrittenPaperViewController.swift; sourceTree = "<group>"; };
 		C5F6954B28FEDCF700365719 /* UIButton+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+Extensions.swift"; sourceTree = "<group>"; };
-		CF0AAF3C291BC4FB000559D6 /* File.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = File.swift; sourceTree = "<group>"; };
 		CF1DEADD28F862720024EA1F /* SidebarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarViewModel.swift; sourceTree = "<group>"; };
 		CFA10C96290585C7002B8653 /* Notification.Name+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification.Name+Extension.swift"; sourceTree = "<group>"; };
 		CFDA52C028F48D08006774E2 /* CategoryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryModel.swift; sourceTree = "<group>"; };
@@ -330,7 +328,6 @@
 			isa = PBXGroup;
 			children = (
 				CFDA52C428F48E96006774E2 /* SidebarViewController.swift */,
-				CF0AAF3C291BC4FB000559D6 /* File.swift */,
 			);
 			path = Sidebar;
 			sourceTree = "<group>";
@@ -677,7 +674,6 @@
 				D2B6308028EE870D008365CB /* UIControl+Extensions.swift in Sources */,
 				C5F6954C28FEDCF700365719 /* UIButton+Extensions.swift in Sources */,
 				D2B6308E28F16493008365CB /* SignUpTextField.swift in Sources */,
-				CF0AAF3D291BC4FB000559D6 /* File.swift in Sources */,
 				AF6FEE3C2902E2E400E44E7D /* CameraCustomPicker.swift in Sources */,
 				D22E4AC428EBFD91001091DA /* SignInViewController.swift in Sources */,
 				D251BDC928ED2A310094ECD9 /* TemplateEnum.swift in Sources */,
@@ -901,7 +897,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = RollingPaper/RollingPaper.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -925,7 +921,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = Yolo.RollingPaper;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = YOLO_Distribution;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = YOLO;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -943,7 +939,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = RollingPaper/RollingPaper.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -967,7 +963,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = Yolo.RollingPaper;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = YOLO_Distribution;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = YOLO;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/RollingPaper/RollingPaper.xcodeproj/project.pbxproj
+++ b/RollingPaper/RollingPaper.xcodeproj/project.pbxproj
@@ -897,7 +897,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = RollingPaper/RollingPaper.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -921,7 +921,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = Yolo.RollingPaper;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = YOLO;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = YOLO_Distribution;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -939,7 +939,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = RollingPaper/RollingPaper.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -963,7 +963,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = Yolo.RollingPaper;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = YOLO;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = YOLO_Distribution;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/RollingPaper/RollingPaper/Models/CategoryModel.swift
+++ b/RollingPaper/RollingPaper/Models/CategoryModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct CategoryModel {
+struct CategoryModel: Hashable {
     let name: String
     var icon: String
 }

--- a/RollingPaper/RollingPaper/ViewControllers/Core/Sidebar/SidebarViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/Sidebar/SidebarViewController.swift
@@ -35,7 +35,7 @@ final class SidebarViewController: UIViewController {
     private var categories: [CategoryModel] = []
     private let viewModel = SidebarViewModel()
     private var cancellables = Set<AnyCancellable>()
-    var sideBarCategories: [CategoryModel] = [
+    private let sideBarCategories: [CategoryModel] = [
         CategoryModel(name: "페이퍼 템플릿", icon: "doc.on.doc"),
         CategoryModel(name: "페이퍼 보관함", icon: "folder"),
         CategoryModel(name: "설정", icon: "gearshape")

--- a/RollingPaper/RollingPaper/ViewControllers/Core/Sidebar/SidebarViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/Sidebar/SidebarViewController.swift
@@ -222,7 +222,7 @@ class CategoryCell: UICollectionViewListCell {
             state.isSelected || state.isHighlighted ? .black : .black
         }
         contentConfig.image = UIImage(systemName: state.isSelected || state.isHighlighted ? categoryData[1] + ".fill" : categoryData[1])
-        
+        contentConfig.imageProperties.tintColor = state.isSelected || state.isHighlighted ? .black : .systemGray3
         guard var backgroundConfig = self.backgroundConfiguration?.updated(for: state) else { return }
         backgroundConfig.backgroundColorTransformer = UIConfigurationColorTransformer { _ in
             state.isSelected || state.isHighlighted ? .white : .clear

--- a/RollingPaper/RollingPaper/ViewControllers/Core/Sidebar/SidebarViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/Sidebar/SidebarViewController.swift
@@ -14,16 +14,14 @@ final private class Layout {
     static let userPhotoFrameWidthHeight = 44
     static let userNameFontSize: CGFloat = 20
     static let userPhotoToNamePadding: CGFloat = 16
-    // static let userChevronFrameWidth = Int(Double(userInfoStackWidthSuperView) * 0.3 * 0.24)
-    // static let userChevronWidthHeight = 15
-    static let collectionViewCellBackgroundInsets = NSDirectionalEdgeInsets(top: 6, leading: 0, bottom: 6, trailing: 0)
+    static let collectionViewCellBackgroundInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 6, trailing: 0)
     static let collectionViewCellimageToTextPadding: CGFloat = 16
     static let collectionViewCellInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
     static let collectionViewHeight: CGFloat = 56
     static let collectionViewCellImageSize = CGSize(width: 25, height: 25)
     static let collectionViewLeadingOffset = 128
     static let collectionViewTrailingOffset = -28
-    static let collectionViewToUserInfoStackPadding = 24
+    static let collectionViewToUserInfoStackPadding = 40
     static let userInfoStackRadius: CGFloat = 12
     static let userInfoStackInset = UIEdgeInsets(top: 14, left: 16, bottom: 14, right: 16)
     static let userInfoStackWidthSuperView = -156
@@ -35,7 +33,7 @@ final private class Layout {
 class SidebarViewController: UIViewController {
     
     private var dataSource: UICollectionViewDiffableDataSource<Section, CategoryModel>! = nil
-    private var collectionView: UICollectionView! = nil
+    // private var collectionView: UICollectionView! = nil
     private var categories: [CategoryModel] = []
     private let viewModel = SidebarViewModel()
     var sideBarCategories: [CategoryModel] = [
@@ -71,6 +69,12 @@ class SidebarViewController: UIViewController {
         return userInfo
     }()
     
+    private lazy var collectionView: UICollectionView = {
+        var collectionView = UICollectionView(frame: view.bounds, collectionViewLayout: setLayout())
+        collectionView.isScrollEnabled = false
+        return collectionView
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .systemGray6
@@ -79,7 +83,11 @@ class SidebarViewController: UIViewController {
         setCollectionView()
         configureDataSource()
     }
-    
+    /*
+    func choose() {
+        collectionView.selectItem(at: IndexPath(index: .ini), animated: <#T##Bool#>, scrollPosition: <#T##UICollectionView.ScrollPosition#>)
+    }
+    */
     private func bind() {
         viewModel
             .currentUserSubject
@@ -114,14 +122,12 @@ class SidebarViewController: UIViewController {
     }
     
     private func setCollectionView() {
-        collectionView = UICollectionView(frame: view.bounds, collectionViewLayout: setLayout())
         view.addSubview(collectionView)
         collectionView.delegate = self
         collectionView.backgroundColor = .clear
-        
         collectionView.snp.makeConstraints { make in
-            make.leading.equalToSuperview().offset(Layout.collectionViewLeadingOffset)
-            make.trailing.equalToSuperview().offset(Layout.collectionViewTrailingOffset)
+            make.leading.equalToSuperview()
+            make.trailing.equalToSuperview()
             make.bottom.equalToSuperview()
             make.top.equalTo(userInfoStack.snp.bottom).offset(Layout.collectionViewToUserInfoStackPadding)
         }
@@ -150,8 +156,13 @@ class SidebarViewController: UIViewController {
     private func configureDataSource() {
         let cellRegistration = UICollectionView.CellRegistration<UICollectionViewListCell, CategoryModel> { (cell, indexPath, category) in
             var content = cell.defaultContentConfiguration()
-            content.text = category.name
             content.image = UIImage(systemName: category.icon)
+            content.text = category.name
+            content.textProperties.font = UIFont.preferredFont(forTextStyle: .title3)
+            content.imageToTextPadding = Layout.collectionViewCellimageToTextPadding
+            content.imageProperties.tintColor = .systemGray3
+            content.imageProperties.maximumSize = Layout.collectionViewCellImageSize
+            content.directionalLayoutMargins = Layout.collectionViewCellInsets
             cell.contentConfiguration = content
         }
         
@@ -184,6 +195,15 @@ extension SidebarViewController: UICollectionViewDelegate {
             name: Notification.Name.viewChangeFromSidebar,
             object: nil,
             userInfo: [NotificationViewKey.view: category.name])
+        if let cell = collectionView.cellForItem(at: indexPath) {
+            cell.contentView.backgroundColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
+        if let cell = collectionView.cellForItem(at: indexPath) {
+                cell.contentView.backgroundColor = nil
+            }
     }
 }
 

--- a/RollingPaper/RollingPaper/ViewControllers/Core/Sidebar/SidebarViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/Sidebar/SidebarViewController.swift
@@ -79,7 +79,7 @@ final class SidebarViewController: UIViewController {
         setProfileView()
         setCollectionView()
         configureDataSource()
-        setinitialConfig()
+        setInitialConfig()
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(changeSecondaryView(noitificaiton:)),
@@ -88,7 +88,7 @@ final class SidebarViewController: UIViewController {
         )
     }
     
-    private func setinitialConfig() {
+    private func setInitialConfig() {
         view.backgroundColor = .systemGray6
         collectionView.selectItem(at: IndexPath(row: 0, section: 0),
                                   animated: false,

--- a/RollingPaper/RollingPaper/ViewControllers/SplitViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/SplitViewController.swift
@@ -18,12 +18,6 @@ class SplitViewController: UISplitViewController, UISplitViewControllerDelegate 
     private var paperTemplateSelectViewController: UINavigationController!
     private var paperStorageViewController: UINavigationController!
     private var settingScreenViewController: UINavigationController!
-    
-    var sideBarCategories: [CategoryModel] = [
-        CategoryModel(name: "페이퍼 템플릿", icon: "doc.on.doc"),
-        CategoryModel(name: "페이퍼 보관함", icon: "folder"),
-        CategoryModel(name: "설정", icon: "gearshape")
-    ]
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/RollingPaper/RollingPaper/ViewControllers/SplitViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/SplitViewController.swift
@@ -36,7 +36,6 @@ class SplitViewController: UISplitViewController, UISplitViewControllerDelegate 
         self.preferredDisplayMode = UISplitViewController.DisplayMode.oneBesideSecondary
         self.presentsWithGesture = true
         self.loadViewControllers()
-        // self.sidebarViewController.show(categories: self.sideBarCategories)
         self.preferredPrimaryColumnWidthFraction = 0.25
         delegate = self
         splitViewManager.transform(input: input.eraseToAnyPublisher())

--- a/RollingPaper/RollingPaper/ViewControllers/SplitViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/SplitViewController.swift
@@ -42,7 +42,7 @@ class SplitViewController: UISplitViewController, UISplitViewControllerDelegate 
         self.preferredDisplayMode = UISplitViewController.DisplayMode.oneBesideSecondary
         self.presentsWithGesture = true
         self.loadViewControllers()
-        self.sidebarViewController.show(categories: self.sideBarCategories)
+        // self.sidebarViewController.show(categories: self.sideBarCategories)
         self.preferredPrimaryColumnWidthFraction = 0.25
         delegate = self
         splitViewManager.transform(input: input.eraseToAnyPublisher())


### PR DESCRIPTION
# Issue Number
🔒 Close #230 

## New features

- write here
- UITableView로 구현되던 사이드바 네비게이션 버튼 UI를 UICollectionView로 바꿨습니다.
    - DiffableDataSource를 사용했습니다.
        - Cell이 선택될 때 마다 아이콘과 backgroundColor가 변합니다. 이때 Cell을 좀더 자연스럽게 업데이트 하기 위해 사용했습니다.
    - UICollectionViewListCell및 UICollectionLayoutListConfiguration.sidebar로 사이드바에 더 알맞은 UI를 구성할 수 있었습니다.
    - CustomCell을 구현하여 셀이 선택 될 시에 카테고리 아이콘과 배경색의 변화를 추가했습니다.
        - 아이콘 변경 로직을 구현하기 위해서 Cell에 프로퍼티를 하나 추가했습니다. (카테고리 이름과 카테고리 아이콘의 이름을 가지고 있습니다.)
        - ![](https://i.imgur.com/LhHCUsX.png)
- 기존에는 SplitViewController에 있던 sidebarCategories를 Sidebar로 옮겼습니다.
    - SidebarViewController를 제외하곤 사용할 필요가 없는 데이터라 SplitViewController에 있을 이유가 없다고 판단하여 옮겼습니다.
- 더 이상 사이드바 네비게이션 버튼들이 스크롤 되지 않습니다.
- 이제 페이퍼 템플릿을 통해 페이퍼를 생성하면 CollectionView의 선택된 Cell이 페이퍼 보관함으로 넘어갑니다.
    - SidebarViewController도 NotificationCenter의 Observer로 등록해서 구현했습니다.
- 초기에 선택되어 있는 Cell을 설정했습니다.
    - 기본 SecondaryView가 PaperTemplate인데 PaperTemplate에 선택 효과가 없어 생길 혼동을 방지하기 위해서 넣었습니다.
- screenshot(optional)
![Simulator Screen Recording - iPad (10th generation) - 2022-11-11 at 01 45 10](https://user-images.githubusercontent.com/57012734/201158777-10803952-6e71-4a0e-9335-d145c17e6dd4.gif)

## Review points

- write here
    - 코드를 거의 새로 생성한 수준이라 눈에 띄는 버그가 있을 수 있습니다. 리뷰 부탁드립니다.
## Questions

- write here
    - 페이퍼를 생성할때 선택된 Cell이 바뀌는 Observer 함수가 하드코딩 되어있습니다. 더 좋은 방법이 있을까요?
    - ![](https://i.imgur.com/da4nkbb.png)

## References

- write here 
    - https://developer.apple.com/documentation/uikit/uicollectionviewdelegate/changing_the_appearance_of_selected_and_highlighted_cells
## Checklist

- [x] Is the branch you are merging on correct?
- [x] Do you comply with coding conventions?
- [x] Are there any changes not related to PR?
- [x] Has my code been self-reviewed?
