### PR TITLE
Feature/handle timer/#251

### DIFF
--- a/RollingPaper/RollingPaper.xcodeproj/project.pbxproj
+++ b/RollingPaper/RollingPaper.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		AFE8D6EC28F6618C005B1F45 /* CardRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE8D6EB28F6618C005B1F45 /* CardRootViewController.swift */; };
 		AFE8D6EE28F6E270005B1F45 /* CardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE8D6ED28F6E270005B1F45 /* CardViewModel.swift */; };
 		BC175412291E180D00A5F57F /* PaperTimePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC175411291E180D00A5F57F /* PaperTimePicker.swift */; };
+		BCC74A79291E1B2300582248 /* TimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC74A78291E1B2300582248 /* TimerView.swift */; };
 		BCE6FEBA291B90430093C36E /* PaperStorageOpenedCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE6FEB9291B90430093C36E /* PaperStorageOpenedCollectionCell.swift */; };
 		BCE6FEBC291B90AA0093C36E /* PaperStorageLength.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE6FEBB291B90AA0093C36E /* PaperStorageLength.swift */; };
 		BCE6FEBE291B917C0093C36E /* PaperStorageClosedCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE6FEBD291B917C0093C36E /* PaperStorageClosedCollectionCell.swift */; };
@@ -100,6 +101,7 @@
 		AFE8D6ED28F6E270005B1F45 /* CardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardViewModel.swift; sourceTree = "<group>"; };
 		BBFE36CDAB55431C5E2625EF /* Pods-RollingPaper.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RollingPaper.debug.xcconfig"; path = "Target Support Files/Pods-RollingPaper/Pods-RollingPaper.debug.xcconfig"; sourceTree = "<group>"; };
 		BC175411291E180D00A5F57F /* PaperTimePicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaperTimePicker.swift; sourceTree = "<group>"; };
+		BCC74A78291E1B2300582248 /* TimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerView.swift; sourceTree = "<group>"; };
 		BCE6FEB9291B90430093C36E /* PaperStorageOpenedCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaperStorageOpenedCollectionCell.swift; sourceTree = "<group>"; };
 		BCE6FEBB291B90AA0093C36E /* PaperStorageLength.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaperStorageLength.swift; sourceTree = "<group>"; };
 		BCE6FEBD291B917C0093C36E /* PaperStorageClosedCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaperStorageClosedCollectionCell.swift; sourceTree = "<group>"; };
@@ -188,6 +190,7 @@
 			children = (
 				D2B6308D28F16493008365CB /* SignUpTextField.swift */,
 				C5A7198A28F883D40003D593 /* UILabel+Padding.swift */,
+				BCC74A78291E1B2300582248 /* TimerView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -673,6 +676,7 @@
 				BC175412291E180D00A5F57F /* PaperTimePicker.swift in Sources */,
 				C5A7198B28F883D40003D593 /* UILabel+Padding.swift in Sources */,
 				D2B6308428EEE2A1008365CB /* UIView+Extensions.swift in Sources */,
+				BCC74A79291E1B2300582248 /* TimerView.swift in Sources */,
 				C5B5853E2900DF1700454C75 /* WrittenPaperViewModel.swift in Sources */,
 				D22E4AD428EC52DB001091DA /* UIApplication+Extensions.swift in Sources */,
 				BCF2481328ED5335008CD0F9 /* PaperTemplateSelectViewModel.swift in Sources */,

--- a/RollingPaper/RollingPaper.xcodeproj/project.pbxproj
+++ b/RollingPaper/RollingPaper.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		AFE8D6EE28F6E270005B1F45 /* CardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE8D6ED28F6E270005B1F45 /* CardViewModel.swift */; };
 		BC175412291E180D00A5F57F /* PaperTimePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC175411291E180D00A5F57F /* PaperTimePicker.swift */; };
 		BCC74A79291E1B2300582248 /* TimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC74A78291E1B2300582248 /* TimerView.swift */; };
+		BCC74A7B291E778800582248 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC74A7A291E778800582248 /* String+Extensions.swift */; };
 		BCE6FEBA291B90430093C36E /* PaperStorageOpenedCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE6FEB9291B90430093C36E /* PaperStorageOpenedCollectionCell.swift */; };
 		BCE6FEBC291B90AA0093C36E /* PaperStorageLength.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE6FEBB291B90AA0093C36E /* PaperStorageLength.swift */; };
 		BCE6FEBE291B917C0093C36E /* PaperStorageClosedCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE6FEBD291B917C0093C36E /* PaperStorageClosedCollectionCell.swift */; };
@@ -102,6 +103,7 @@
 		BBFE36CDAB55431C5E2625EF /* Pods-RollingPaper.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RollingPaper.debug.xcconfig"; path = "Target Support Files/Pods-RollingPaper/Pods-RollingPaper.debug.xcconfig"; sourceTree = "<group>"; };
 		BC175411291E180D00A5F57F /* PaperTimePicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaperTimePicker.swift; sourceTree = "<group>"; };
 		BCC74A78291E1B2300582248 /* TimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerView.swift; sourceTree = "<group>"; };
+		BCC74A7A291E778800582248 /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
 		BCE6FEB9291B90430093C36E /* PaperStorageOpenedCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaperStorageOpenedCollectionCell.swift; sourceTree = "<group>"; };
 		BCE6FEBB291B90AA0093C36E /* PaperStorageLength.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaperStorageLength.swift; sourceTree = "<group>"; };
 		BCE6FEBD291B917C0093C36E /* PaperStorageClosedCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaperStorageClosedCollectionCell.swift; sourceTree = "<group>"; };
@@ -267,6 +269,7 @@
 				D2CB508E28FD49E70065C2A9 /* UNUserNotificationCenter+Extensions.swift */,
 				C5B5853B29001AFF00454C75 /* UIImage+Extension.swift */,
 				CFA10C96290585C7002B8653 /* Notification.Name+Extension.swift */,
+				BCC74A7A291E778800582248 /* String+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -711,6 +714,7 @@
 				D2B6308628EF0BCB008365CB /* UIFont+Extensions.swift in Sources */,
 				D22E4AC928EBFDDF001091DA /* SignInViewModel.swift in Sources */,
 				D22E4AC228EBFD7B001091DA /* FirestoreManager.swift in Sources */,
+				BCC74A7B291E778800582248 /* String+Extensions.swift in Sources */,
 				D251BDCB28ED32890094ECD9 /* UIColor+Extensions.swift in Sources */,
 				D2CB508F28FD49E70065C2A9 /* UNUserNotificationCenter+Extensions.swift in Sources */,
 				CFA10C97290585C7002B8653 /* Notification.Name+Extension.swift in Sources */,

--- a/RollingPaper/RollingPaper/Components/TimerView.swift
+++ b/RollingPaper/RollingPaper/Components/TimerView.swift
@@ -63,12 +63,13 @@ class TimerView: UIStackView {
     func updateTime() {
         guard let endTime = endTime else {return}
         let timeInterval = Int(endTime.timeIntervalSince(Date()))
+        
         // 30분 기준으로 타이머 색상 변경
         backgroundColor = timeInterval > 60*30 ? UIColor.black.withAlphaComponent(0.32) : UIColor.red
         time.text = changeTimeFormat(second: timeInterval)
     }
     
-    // 초를 특정 포맷으로 바꾸기
+    // 초를 특정 포맷으로 바꾸기 (00시간 00분 00초)
     private func changeTimeFormat(second: Int) -> String {
         let hourSuffix = "시간" + " "
         let minSuffix = "분" + " "
@@ -105,7 +106,7 @@ class TimerView: UIStackView {
 
 // 타이머 시간 흐르게 하는 클래스
 class TimerViewModel {
-    private let timerInterval = 1.0 // 1초
+    private let timerInterval = 1.0 // 1초 간격
     private let output: PassthroughSubject<Output, Never> = .init()
     private var cancellables = Set<AnyCancellable>()
     private var timer: AnyCancellable?
@@ -124,6 +125,7 @@ class TimerViewModel {
             .receive(on: DispatchQueue.global(qos: .background))
             .sink(receiveValue: { [weak self] _ in
                 guard let self = self else {return}
+                // 타이머 업데이트 됐다고 알려주기
                 self.output.send(.timeIsUpdated)
             })
     }
@@ -137,10 +139,8 @@ class TimerViewModel {
                 switch event {
                 case .viewDidAppear:
                     self.bindTimer()
-                    print("aaa bind!!")
                 case .viewDidDisappear:
                     self.timer?.cancel()
-                    print("aaa cancel!!!")
                 }
             })
             .store(in: &cancellables)

--- a/RollingPaper/RollingPaper/Components/TimerView.swift
+++ b/RollingPaper/RollingPaper/Components/TimerView.swift
@@ -1,0 +1,102 @@
+//
+//  TimerView.swift
+//  RollingPaper
+//
+//  Created by 김동락 on 2022/11/11.
+//
+
+import UIKit
+import SnapKit
+
+private class Length {
+    static let timerTopPadding: CGFloat = 6
+    static let timerBottomPadding: CGFloat = 6
+    static let timerRightPadding: CGFloat = 8
+    static let timerLeftPadding: CGFloat = 8
+    static let timerSpace: CGFloat = 4
+    static let timerCornerRadius: CGFloat = 16 // 바꿔야함
+    static let clockImageWidth: CGFloat = 20
+    static let clockImageHeight: CGFloat = 20
+}
+
+class TimerView: UIStackView {
+    private var endTime: Date?
+    private let clock = UIImageView()
+    private let time = UILabel()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setLayout()
+    }
+    
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // 페이퍼 끝나는 시간 설정하도록 하기
+    func setEndTime(time: Date) {
+        endTime = time
+        updateTime(now: Date())
+    }
+    
+    // 레이아웃 세팅하기
+    private func setLayout() {
+        addArrangedSubview(clock)
+        addArrangedSubview(time)
+        
+        layer.cornerRadius = Length.timerCornerRadius
+        distribution = .equalSpacing
+        layoutMargins = UIEdgeInsets(top: Length.timerTopPadding, left: Length.timerLeftPadding, bottom: Length.timerBottomPadding, right: Length.timerRightPadding)
+        isLayoutMarginsRelativeArrangement = true
+        spacing = Length.timerSpace
+        
+        clock.image = UIImage(systemName: "timer")
+        clock.tintColor = UIColor.white
+        clock.contentMode = .scaleAspectFit
+        clock.snp.makeConstraints({ make in
+            make.width.equalTo(Length.clockImageWidth)
+            make.height.equalTo(Length.clockImageHeight)
+        })
+        
+        time.font = .preferredFont(for: .subheadline, weight: .semibold)
+        time.textAlignment = .right
+        time.textColor = UIColor.white
+    }
+    
+    // 타이머 남은 시간 업데이트하기
+    private func updateTime(now: Date) {
+        guard let endTime = endTime else {return}
+        let timeInterval = Int(endTime.timeIntervalSince(now))
+        // 30분 기준으로 타이머 색상 변경
+        backgroundColor = timeInterval > 60*30 ? UIColor.black.withAlphaComponent(0.32) : UIColor.red
+        time.text = changeTimeFormat(second: timeInterval)
+    }
+    
+    // 초를 특정 포맷으로 바꾸기
+    private func changeTimeFormat(second: Int) -> String {
+        let hourSuffix = "시간" + " "
+        let minSuffix = "분" + " "
+        let secSuffix = "초"
+        
+        let hour = Int(second/3600)
+        let min = Int((second - (hour*3600))/60)
+        let sec = second - (hour*3600+min*60)
+
+        var hourString = String(hour)+hourSuffix
+        var minString = String(min)+minSuffix
+        var secString = String(sec)+secSuffix
+        
+        if hourString.count == 1+hourSuffix.count { hourString = "0" + hourString }
+        if minString.count == 1+minSuffix.count { minString = "0" + minString }
+        if secString.count == 1+secSuffix.count { secString = "0" + secString }
+        
+        if hour == 0 {
+            hourString = ""
+            if min == 0 {
+                minString = ""
+            }
+        }
+        
+        return hourString + minString + secString
+    }
+}

--- a/RollingPaper/RollingPaper/Components/TimerView.swift
+++ b/RollingPaper/RollingPaper/Components/TimerView.swift
@@ -10,6 +10,10 @@ import SnapKit
 import Combine
 
 private class Length {
+    static let timerHeight: CGFloat = 32
+    static let timerWidth1: CGFloat = 172
+    static let timerWidth2: CGFloat = 116
+    static let timerWidth3: CGFloat = 78
     static let timerTopPadding: CGFloat = 6
     static let timerBottomPadding: CGFloat = 6
     static let timerRightPadding: CGFloat = 8
@@ -18,6 +22,9 @@ private class Length {
     static let timerCornerRadius: CGFloat = 16 // 바꿔야함
     static let clockImageWidth: CGFloat = 20
     static let clockImageHeight: CGFloat = 20
+    static let textWidth1: CGFloat = 132
+    static let textWidth2: CGFloat = 76
+    static let textWidth3: CGFloat = 38
 }
 
 // 타이머 UI
@@ -25,6 +32,10 @@ class TimerView: UIStackView {
     private let clock = UIImageView()
     private let time = UILabel()
     private var endTime: Date?
+    private var remainTimeState: RemainTimeState = .hour
+    enum RemainTimeState {
+        case hour, minute, second
+    }
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -46,6 +57,11 @@ class TimerView: UIStackView {
         isLayoutMarginsRelativeArrangement = true
         spacing = Length.timerSpace
         
+        snp.makeConstraints ({ make in
+            make.width.equalTo(Length.timerWidth1)
+            make.height.equalTo(Length.timerHeight)
+        })
+        
         clock.image = UIImage(systemName: "timer")
         clock.tintColor = UIColor.white
         clock.contentMode = .scaleAspectFit
@@ -54,9 +70,12 @@ class TimerView: UIStackView {
             make.height.equalTo(Length.clockImageHeight)
         })
         
-        time.font = .preferredFont(for: .subheadline, weight: .semibold)
-        time.textAlignment = .right
+        time.font = .systemFont(ofSize: 16, weight: .semibold)
+        time.textAlignment = .center
         time.textColor = UIColor.white
+        time.snp.makeConstraints({ make in
+            make.width.equalTo(Length.textWidth1)
+        })
     }
     
     // 타이머 남은 시간 업데이트하기
@@ -66,6 +85,34 @@ class TimerView: UIStackView {
         
         // 30분 기준으로 타이머 색상 변경
         backgroundColor = timeInterval > 60*30 ? UIColor.black.withAlphaComponent(0.32) : UIColor.red
+        
+        // 남은 시간에 따라 레이아웃 가로 길이 조절
+        if timeInterval >= 0 && timeInterval < 60 && remainTimeState != .second {
+            remainTimeState = .second
+            snp.updateConstraints({ make in
+                make.width.equalTo(Length.timerWidth3)
+            })
+            time.snp.updateConstraints({ make in
+                make.width.equalTo(Length.textWidth3)
+            })
+        } else if timeInterval >= 60 && timeInterval < 3600 && remainTimeState != .minute {
+            remainTimeState = .minute
+            snp.updateConstraints({ make in
+                make.width.equalTo(Length.timerWidth2)
+            })
+            time.snp.updateConstraints({ make in
+                make.width.equalTo(Length.textWidth2)
+            })
+        } else if timeInterval >= 3600 && remainTimeState != .hour  {
+            remainTimeState = .hour
+            snp.updateConstraints({ make in
+                make.width.equalTo(Length.timerWidth1)
+            })
+            time.snp.updateConstraints({ make in
+                make.width.equalTo(Length.textWidth1)
+            })
+        }
+        
         time.text = changeTimeFormat(second: timeInterval)
     }
     

--- a/RollingPaper/RollingPaper/Extensions/String+Extensions.swift
+++ b/RollingPaper/RollingPaper/Extensions/String+Extensions.swift
@@ -1,0 +1,19 @@
+//
+//  String+Extensions.swift
+//  RollingPaper
+//
+//  Created by 김동락 on 2022/11/11.
+//
+
+import Foundation
+
+extension String {
+    func substring(start: Int, end: Int) -> String {
+        guard start < count, end >= 0, end - start >= 0 else {
+            return ""
+        }
+        let startIndex = index(self.startIndex, offsetBy: start)
+        let endIndex = index(self.startIndex, offsetBy: end)
+        return String(self[startIndex ..< endIndex])
+    }
+}

--- a/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageOpenedCollectionCell.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageOpenedCollectionCell.swift
@@ -15,6 +15,7 @@ class PaperStorageOpenedCollectionCell: UICollectionViewCell {
     private var cancellables = Set<AnyCancellable>()
     private let cell = UIView()
     private let preview = UIImageView()
+    private let previewOverlay = UIView()
     private let timer = TimerView()
     private let title = UILabel()
     
@@ -32,6 +33,7 @@ class PaperStorageOpenedCollectionCell: UICollectionViewCell {
         cell.addSubview(preview)
         cell.addSubview(timer)
         cell.addSubview(title)
+        preview.addSubview(previewOverlay)
         
         cell.snp.makeConstraints({ make in
             make.edges.equalToSuperview()
@@ -45,6 +47,11 @@ class PaperStorageOpenedCollectionCell: UICollectionViewCell {
             make.leading.equalToSuperview()
             make.width.equalTo(PaperStorageLength.openedPaperThumbnailWidth)
             make.height.equalTo(PaperStorageLength.openedPaperThumbnailHeight)
+        })
+        
+        previewOverlay.backgroundColor = UIColor.black.withAlphaComponent(0.25)
+        previewOverlay.snp.makeConstraints({ make in
+            make.edges.equalToSuperview()
         })
         
         title.font = .preferredFont(for: .title1, weight: .semibold)

--- a/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageOpenedCollectionCell.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageOpenedCollectionCell.swift
@@ -7,15 +7,15 @@
 
 import UIKit
 import SnapKit
+import Combine
 
 // 컬렉션 뷰에 들어가는 셀들을 보여주는 뷰 (진행중인거)
 class PaperStorageOpenedCollectionCell: UICollectionViewCell {
     static let identifier = "OpenedCollectionCell"
+    private var cancellables = Set<AnyCancellable>()
     private let cell = UIView()
     private let preview = UIImageView()
-    private let timer = UIStackView()
-    private let clock = UIImageView()
-    private let time = UILabel()
+    private let timer = TimerView()
     private let title = UILabel()
     
     override init(frame: CGRect) {
@@ -32,8 +32,6 @@ class PaperStorageOpenedCollectionCell: UICollectionViewCell {
         cell.addSubview(preview)
         cell.addSubview(timer)
         cell.addSubview(title)
-        timer.addArrangedSubview(clock)
-        timer.addArrangedSubview(time)
         
         cell.snp.makeConstraints({ make in
             make.edges.equalToSuperview()
@@ -58,62 +56,14 @@ class PaperStorageOpenedCollectionCell: UICollectionViewCell {
             make.leading.equalTo(preview.snp.leading).offset(PaperStorageLength.openedPaperTitleLeftMargin)
         })
         
-        timer.layer.cornerRadius = PaperStorageLength.timerCornerRadius
-        timer.distribution = .equalSpacing
-        timer.layoutMargins = UIEdgeInsets(top: PaperStorageLength.timerTopPadding, left: PaperStorageLength.timerLeftPadding, bottom: PaperStorageLength.timerBottomPadding, right: PaperStorageLength.timerRightPadding)
-        timer.isLayoutMarginsRelativeArrangement = true
-        timer.layer.cornerRadius = PaperStorageLength.timerCornerRadius
-        timer.spacing = PaperStorageLength.timerSpace
         timer.snp.makeConstraints({ make in
             make.top.equalTo(preview.snp.top).offset(PaperStorageLength.timerTopMargin)
             make.leading.equalTo(preview.snp.leading).offset(PaperStorageLength.timerLeftMargin)
         })
-        
-        clock.image = UIImage(systemName: "timer")
-        clock.tintColor = UIColor.white
-        clock.contentMode = .scaleAspectFit
-        clock.snp.makeConstraints({ make in
-            make.width.equalTo(PaperStorageLength.clockImageWidth)
-            make.height.equalTo(PaperStorageLength.clockImageHeight)
-        })
-        
-        time.font = .preferredFont(for: .subheadline, weight: .semibold)
-        time.textAlignment = .right
-        time.textColor = UIColor.white
-    }
-    
-    // 초를 05:17(시간:분) 형식으로 바꾸기
-    private func changeTimeFormat(second: Int) -> String {
-        let hour = Int(second/3600)
-        let minute = Int((second - (hour*3600))/60)
-        var hourString = String(hour)
-        var minuteString = String(minute)
-        if hourString.count == 1 {
-            hourString = "0" + hourString
-        }
-        if minuteString.count == 1 {
-            minuteString = "0" + minuteString
-        }
-        
-        return hourString + ":" + minuteString
-    }
-    
-    // 날짜를 2022.10.13 같은 형식으로 바꾸기
-    private func changeDateFormat(date: Date) -> String {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "y.M.d"
-        return dateFormatter.string(from: date)
     }
     
     func setCell(paper: PaperPreviewModel, thumbnail: UIImage?, now: Date) {
-        let timeInterval = Int(paper.endTime.timeIntervalSince(now))
-        // 10분 이상 남은 페이퍼라면
-        if timeInterval > 600 {
-            timer.backgroundColor = UIColor.black.withAlphaComponent(0.32)
-        } else {
-            timer.backgroundColor = UIColor.red
-        }
-        time.text = changeTimeFormat(second: timeInterval)
+        timer.setEndTime(time: paper.endTime)
         title.text = paper.title
         preview.image = thumbnail
         preview.snp.updateConstraints({ make in

--- a/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageViewController.swift
@@ -36,14 +36,14 @@ class PaperStorageViewController: UIViewController {
         self.splitViewController?.show(.primary)
     }
     
-    // view가 나타나면 알려주기
+    // 뷰모델한테 뷰 나타났다고 알려주기
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         input.send(.viewDidAppear)
         viewIsChange = false
     }
     
-    // view가 사라지면 알려주기
+    // 뷰모델한테 뷰 사라졌다고 알려주기
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         input.send(.viewDidDisappear)
@@ -66,6 +66,7 @@ class PaperStorageViewController: UIViewController {
             .store(in: &cancellables)
     }
     
+    // 진행중인거, 종료된거에 따라 상태 변경하기
     private func setDataState() {
         if viewModel.openedPapers.isEmpty && viewModel.closedPapers.isEmpty {
             dataState = .nothing

--- a/RollingPaper/RollingPaper/ViewControllers/Core/PaperTemplate/PaperSettingViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/PaperTemplate/PaperSettingViewController.swift
@@ -253,7 +253,7 @@ class PaperSettingViewController: UIViewController {
     // 피커 버튼 가져오기
     private func initTimePickerButton() {
         timePickerButton.addTarget(self, action: #selector(onClickedTimePickerButton(_:)), for: .touchUpInside)
-        timePickerButton.setTitle("1시간 00분", for: .normal)
+        timePickerButton.setTitle(PaperSettingViewModel.defaultTime, for: .normal)
         timePickerButton.setTitleColor(.black, for: .normal)
         timePickerButton.backgroundColor = .black
         timePickerButton.layer.cornerRadius = Length.timePickerButtonRadius

--- a/RollingPaper/RollingPaper/ViewControllers/Core/PaperTemplate/PaperSettingViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/PaperTemplate/PaperSettingViewController.swift
@@ -33,7 +33,7 @@ private class Length {
     static let titleLengthLabelHeight: CGFloat = 28
     static let warningLabelTopMargin: CGFloat = 10
     static let timePickerLeftMargin: CGFloat = 18
-    static let timePickerButtonWidth: CGFloat = 86
+    static let timePickerButtonWidth: CGFloat = 120
     static let timePickerButtonHeight: CGFloat = 36
     static let timePickerButtonRadius: CGFloat = 6
 }
@@ -253,7 +253,7 @@ class PaperSettingViewController: UIViewController {
     // 피커 버튼 가져오기
     private func initTimePickerButton() {
         timePickerButton.addTarget(self, action: #selector(onClickedTimePickerButton(_:)), for: .touchUpInside)
-        timePickerButton.setTitle("00:30", for: .normal)
+        timePickerButton.setTitle("1시간 00분", for: .normal)
         timePickerButton.setTitleColor(.black, for: .normal)
         timePickerButton.backgroundColor = .black
         timePickerButton.layer.cornerRadius = Length.timePickerButtonRadius

--- a/RollingPaper/RollingPaper/ViewControllers/Core/PaperTemplate/PaperTimePicker.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/PaperTemplate/PaperTimePicker.swift
@@ -10,7 +10,12 @@ import Combine
 
 // 제한시간 설정할 때 쓰는 피커
 class PaperTimePicker: UIViewController {
-    private let timeList = ["00:30", "01:00", "01:30", "02:00", "02:30", "03:00", "03:30", "04:00"]
+    private let hourList = ["1", "2", "3", "4", "5", "6"]
+    private let minuteList = ["00", "10", "20", "30", "40", "50"]
+    private let hourLabel = "시간"
+    private let minuteLabel = "분"
+    private var selectedHour = "1"
+    private var selectedMinute = "00"
     private let picker = UIPickerView()
     private let viewModel: PaperSettingViewModel
     private let input: PassthroughSubject<PaperSettingViewModel.Input, Never> = .init()
@@ -40,6 +45,8 @@ class PaperTimePicker: UIViewController {
     private func setPicker() {
         picker.delegate = self
         picker.dataSource = self
+        setPickerLabelsWith(labels: [hourLabel, minuteLabel], lengths: [hourList[0].count, minuteList[0].count])
+        
         picker.snp.makeConstraints({ make in
             make.edges.equalToSuperview()
         })
@@ -55,23 +62,58 @@ class PaperTimePicker: UIViewController {
     private func compressView() {
         preferredContentSize = view.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
     }
+    // 라벨 달기
+    func setPickerLabelsWith(labels: [String], lengths: [Int]) {
+        let columCount = labels.count
+        let fontSize: CGFloat = 20
+
+        var labelList: [UILabel] = []
+        for index in 0..<columCount {
+            let label = UILabel()
+            label.text = labels[index]
+            label.font = .systemFont(ofSize: fontSize)
+            label.textColor = .black
+            label.sizeToFit()
+            labelList.append(label)
+        }
+
+        let pickerWidth: CGFloat = picker.frame.width
+        let labelY: CGFloat = (picker.frame.size.height / 2) - 3
+
+        for (index, label) in labelList.enumerated() {
+            let labelX: CGFloat = (pickerWidth / (CGFloat(columCount)*2))
+                                    * CGFloat(index + 1)
+                                    + fontSize*CGFloat(lengths[index])
+                                    - fontSize*0.5*CGFloat(lengths[index]-1)
+            label.frame = CGRect(x: labelX, y: labelY, width: fontSize*CGFloat(labels[index].count), height: fontSize)
+            picker.addSubview(label)
+        }
+    }
 }
 
 extension PaperTimePicker: UIPickerViewDelegate, UIPickerViewDataSource {
     // 컴포넌트(목록) 개수
     func numberOfComponents(in pickerView: UIPickerView) -> Int {
-        return 1
+        return 2
     }
     // 컴포넌트 별 아이템 개수
     func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
-        return timeList.count
+        return component == 0 ? hourList.count : minuteList.count
     }
     // 보여주는 아이템
     func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-        return timeList[row]
+        return component == 0 ? hourList[row] : minuteList[row]
     }
     // 선택된 아이템
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
-        input.send(.timePickerChange(time: timeList[row]))
+        if component == 0 {
+            selectedHour = hourList[row]
+        } else {
+            selectedMinute = minuteList[row]
+        }
+        input.send(.timePickerChange(time: selectedHour+hourLabel+" "+selectedMinute+minuteLabel))
+    }
+    func pickerView(_ pickerView: UIPickerView, widthForComponent component: Int) -> CGFloat {
+        return CGFloat(80.0)
     }
 }


### PR DESCRIPTION
# Issue Number
🔒 Close #251
🔒 Close #243

## New features
- 보관함에서 페이퍼 썸네일에 투명도 있는 검은 배경 씌움
- 서브스트링 구하기 번거로워서 String Extension으로 해당 함수 추가해둠
- 페이퍼 생성시 제한 시간을 설정하는 피커를 두개의 열로 나누고 라벨을 추가
- 피커를 통해 설정된 제한 시간(String)을 종료 시간(Date)으로 변환한 뒤 페이퍼 프로퍼티에 추가되도록 함
- 분리 작업을 통해 타이머 컴포넌트를 따로 빼놓고 보관함 뷰에 다시 적용
- 타이머 라벨 피그마에 나와있는대로 디자인함 (남은 시간에 따라 가로 길이 변함, 30분 남았을 때 빨간색)
- 사이먼 뷰에도 잘 작동되는거 확인 (*이건 Conflict 예방을 위해 따로 커밋은 안했음 - 나중에 사이먼한테 코드 알려줄 예정)

![Simulator Screen Recording - iPad mini (6th generation) - 2022-11-11 at 22 51 49](https://user-images.githubusercontent.com/72330884/201355629-86bf5c54-a904-4c84-b0f5-ced733767526.gif)

![Simulator Screen Recording - iPad mini (6th generation) - 2022-11-11 at 22 50 24](https://user-images.githubusercontent.com/72330884/201355643-1b9debad-3410-4077-a4ab-fa97ac4b737a.gif)

![Simulator Screen Shot - iPad mini (6th generation) - 2022-11-11 at 22 51 02](https://user-images.githubusercontent.com/72330884/201355656-44e7ff4d-3e19-48f5-9542-e6a4f6a6204c.png)


## Checklist
- [X] Is the branch you are merging on correct?
- [X] Do you comply with coding conventions?
- [X] Are there any changes not related to PR?
- [X] Has my code been self-reviewed?
