### PR TITLE
Fix/user photos remaining when logged out/#255 #256

### DIFF
--- a/RollingPaper/RollingPaper/Managers/FirebaseAuthManager.swift
+++ b/RollingPaper/RollingPaper/Managers/FirebaseAuthManager.swift
@@ -75,6 +75,8 @@ final class FirebaseAuthManager: NSObject, AuthManager {
                     let userModel = userModel,
                     let userProfileURLString = userModel.profileUrl {
                     self?.handleProfileImage(with: userProfileURLString)
+                } else {
+                    self?.userProfileImageSubject.send(nil)
                 }
             }
             .store(in: &cancellables)

--- a/RollingPaper/RollingPaper/ViewControllers/Core/Sidebar/SidebarViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/Sidebar/SidebarViewController.swift
@@ -43,9 +43,7 @@ final class SidebarViewController: UIViewController {
     
     private let userPhoto: UIImageView = {
         let photo = UIImageView()
-        photo.layer.cornerRadius = photo.frame.width / 2
-        photo.layer.masksToBounds = true
-        photo.contentMode = UIView.ContentMode.scaleAspectFit
+        photo.contentMode = UIView.ContentMode.scaleAspectFill
         return photo
     }()
     
@@ -76,8 +74,6 @@ final class SidebarViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         bind()
-        setProfileView()
-        setCollectionView()
         configureDataSource()
         setInitialConfig()
         NotificationCenter.default.addObserver(
@@ -86,6 +82,12 @@ final class SidebarViewController: UIViewController {
             name: Notification.Name.viewChange,
             object: nil
         )
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        setProfileView()
+        setCollectionView()
     }
     
     private func setInitialConfig() {
@@ -198,7 +200,7 @@ final class SidebarViewController: UIViewController {
             make.width.equalTo(userPhoto.snp.height)
         }
         userPhoto.layer.cornerRadius = userPhoto.frame.width / 2
-        userPhoto.contentMode = .scaleAspectFill
+        userPhoto.layer.masksToBounds = true
     }
 }
 


### PR DESCRIPTION
# Issue Number
🔒 Close #255
🔒 Close #256

## New features

- write here
- Sidebar UserProfile의 UserPhoto가 가지고 있는 두가지 버그를 해결했습니다.
    - 같은곳에서 작은 크기의 두 버그가 생겨서 동시에 해결했습니다. (이슈 #255, #256)
    - UserPhoto의 둥근 Frame이 잘 적용되지 않는 버그를 해결했습니다.
        - Sidebar의 UI를 UITableView에서 UICollectionView로 Refactoring하는 과정에서 viewDidLayoutSubviews()에 있는 Method들을 viewDidLoad()로 통합하면서 생긴 버그였습니다.
        - viewDidLoad()가 실행되는 동안에는 UserPhoto의 Size를 잘 받아오지 못합니다.
        - viewDidLayoutSubviews()를 새로 Override 받아 해결했습니다.
    - Sign Out을 했을때 UserPhoto가 그대로 남아있는 버그를 해결했습니다.
        - UserProfile을 bind할 때, image URL이 있을 때만 image를 갱신해서 생기는 버그였습니다.
        - image가 없을 때 nil을 send하는 코드를 삽입해서 해결했습니다.

- screenshot(optional)
![Simulator Screen Recording - iPad (10th generation) - 2022-11-14 at 10 56 06](https://user-images.githubusercontent.com/57012734/201559266-3a7fb50e-c10b-4dc8-b96c-c3f9b465509d.gif)

## Review points

- 놓친 버그가 없는지 확인해 주세요.

## Checklist

- [x] Is the branch you are merging on correct?
- [x] Do you comply with coding conventions?
- [x] Are there any changes not related to PR?
- [x] Has my code been self-reviewed?
