### PR TITLE
Feature/loading view in paper storage/#268

### DIFF
--- a/RollingPaper/RollingPaper.xcodeproj/project.pbxproj
+++ b/RollingPaper/RollingPaper.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		AFE8D6EC28F6618C005B1F45 /* CardRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE8D6EB28F6618C005B1F45 /* CardRootViewController.swift */; };
 		AFE8D6EE28F6E270005B1F45 /* CardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE8D6ED28F6E270005B1F45 /* CardViewModel.swift */; };
 		BC175412291E180D00A5F57F /* PaperTimePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC175411291E180D00A5F57F /* PaperTimePicker.swift */; };
+		BC95A92D292212CF00124665 /* TimeFlowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC95A92C292212CF00124665 /* TimeFlowManager.swift */; };
 		BCC74A79291E1B2300582248 /* TimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC74A78291E1B2300582248 /* TimerView.swift */; };
 		BCC74A7B291E778800582248 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC74A7A291E778800582248 /* String+Extensions.swift */; };
 		BCC74A7D2922050B00582248 /* PaperSettingLength.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC74A7C2922050B00582248 /* PaperSettingLength.swift */; };
@@ -108,6 +109,7 @@
 		AFE8D6ED28F6E270005B1F45 /* CardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardViewModel.swift; sourceTree = "<group>"; };
 		BBFE36CDAB55431C5E2625EF /* Pods-RollingPaper.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RollingPaper.debug.xcconfig"; path = "Target Support Files/Pods-RollingPaper/Pods-RollingPaper.debug.xcconfig"; sourceTree = "<group>"; };
 		BC175411291E180D00A5F57F /* PaperTimePicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaperTimePicker.swift; sourceTree = "<group>"; };
+		BC95A92C292212CF00124665 /* TimeFlowManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeFlowManager.swift; sourceTree = "<group>"; };
 		BCC74A78291E1B2300582248 /* TimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerView.swift; sourceTree = "<group>"; };
 		BCC74A7A291E778800582248 /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
 		BCC74A7C2922050B00582248 /* PaperSettingLength.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaperSettingLength.swift; sourceTree = "<group>"; };
@@ -328,6 +330,7 @@
 				D2B6308928F158E7008365CB /* LocalDatabaseMockManager.swift */,
 				D2CB508C28FD2CB50065C2A9 /* NSCacheManager.swift */,
 				BCF2482429012589008CD0F9 /* SplitViewManager.swift */,
+				BC95A92C292212CF00124665 /* TimeFlowManager.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -733,6 +736,7 @@
 				D2B6308628EF0BCB008365CB /* UIFont+Extensions.swift in Sources */,
 				D22E4AC928EBFDDF001091DA /* SignInViewModel.swift in Sources */,
 				D22E4AC228EBFD7B001091DA /* FirestoreManager.swift in Sources */,
+				BC95A92D292212CF00124665 /* TimeFlowManager.swift in Sources */,
 				BCC74A7B291E778800582248 /* String+Extensions.swift in Sources */,
 				D251BDCB28ED32890094ECD9 /* UIColor+Extensions.swift in Sources */,
 				D2CB508F28FD49E70065C2A9 /* UNUserNotificationCenter+Extensions.swift in Sources */,

--- a/RollingPaper/RollingPaper.xcodeproj/project.pbxproj
+++ b/RollingPaper/RollingPaper.xcodeproj/project.pbxproj
@@ -20,6 +20,10 @@
 		BC175412291E180D00A5F57F /* PaperTimePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC175411291E180D00A5F57F /* PaperTimePicker.swift */; };
 		BCC74A79291E1B2300582248 /* TimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC74A78291E1B2300582248 /* TimerView.swift */; };
 		BCC74A7B291E778800582248 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC74A7A291E778800582248 /* String+Extensions.swift */; };
+		BCC74A7D2922050B00582248 /* PaperSettingLength.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC74A7C2922050B00582248 /* PaperSettingLength.swift */; };
+		BCC74A7F292205A200582248 /* PaperTemplateCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC74A7E292205A200582248 /* PaperTemplateCollectionCell.swift */; };
+		BCC74A812922061000582248 /* PaperTemplateSelectLength.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC74A802922061000582248 /* PaperTemplateSelectLength.swift */; };
+		BCC74A83292208ED00582248 /* PaperTemplateCollectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC74A82292208ED00582248 /* PaperTemplateCollectionHeader.swift */; };
 		BCE6FEBA291B90430093C36E /* PaperStorageOpenedCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE6FEB9291B90430093C36E /* PaperStorageOpenedCollectionCell.swift */; };
 		BCE6FEBC291B90AA0093C36E /* PaperStorageLength.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE6FEBB291B90AA0093C36E /* PaperStorageLength.swift */; };
 		BCE6FEBE291B917C0093C36E /* PaperStorageClosedCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE6FEBD291B917C0093C36E /* PaperStorageClosedCollectionCell.swift */; };
@@ -102,11 +106,14 @@
 		AFE8D6E828F50319005B1F45 /* CardCreateViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardCreateViewController.swift; sourceTree = "<group>"; };
 		AFE8D6EB28F6618C005B1F45 /* CardRootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardRootViewController.swift; sourceTree = "<group>"; };
 		AFE8D6ED28F6E270005B1F45 /* CardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardViewModel.swift; sourceTree = "<group>"; };
-		AFEEFDCC291E2F350030534A /* PaperTimePicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PaperTimePicker.swift; path = ../../../../../../../../PaperTimePicker.swift; sourceTree = "<group>"; };
 		BBFE36CDAB55431C5E2625EF /* Pods-RollingPaper.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RollingPaper.debug.xcconfig"; path = "Target Support Files/Pods-RollingPaper/Pods-RollingPaper.debug.xcconfig"; sourceTree = "<group>"; };
 		BC175411291E180D00A5F57F /* PaperTimePicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaperTimePicker.swift; sourceTree = "<group>"; };
 		BCC74A78291E1B2300582248 /* TimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerView.swift; sourceTree = "<group>"; };
 		BCC74A7A291E778800582248 /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
+		BCC74A7C2922050B00582248 /* PaperSettingLength.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaperSettingLength.swift; sourceTree = "<group>"; };
+		BCC74A7E292205A200582248 /* PaperTemplateCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaperTemplateCollectionCell.swift; sourceTree = "<group>"; };
+		BCC74A802922061000582248 /* PaperTemplateSelectLength.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaperTemplateSelectLength.swift; sourceTree = "<group>"; };
+		BCC74A82292208ED00582248 /* PaperTemplateCollectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaperTemplateCollectionHeader.swift; sourceTree = "<group>"; };
 		BCE6FEB9291B90430093C36E /* PaperStorageOpenedCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaperStorageOpenedCollectionCell.swift; sourceTree = "<group>"; };
 		BCE6FEBB291B90AA0093C36E /* PaperStorageLength.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaperStorageLength.swift; sourceTree = "<group>"; };
 		BCE6FEBD291B917C0093C36E /* PaperStorageClosedCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaperStorageClosedCollectionCell.swift; sourceTree = "<group>"; };
@@ -356,9 +363,13 @@
 		D24145202919F92300437FE7 /* PaperTemplate */ = {
 			isa = PBXGroup;
 			children = (
-				BC175411291E180D00A5F57F /* PaperTimePicker.swift */,
+				BCC74A802922061000582248 /* PaperTemplateSelectLength.swift */,
+				BCC74A7C2922050B00582248 /* PaperSettingLength.swift */,
 				BCF2481028ED512A008CD0F9 /* PaperTemplateSelectViewController.swift */,
+				BCC74A82292208ED00582248 /* PaperTemplateCollectionHeader.swift */,
+				BCC74A7E292205A200582248 /* PaperTemplateCollectionCell.swift */,
 				BCF2481628EFC499008CD0F9 /* PaperSettingViewController.swift */,
+				BC175411291E180D00A5F57F /* PaperTimePicker.swift */,
 			);
 			path = PaperTemplate;
 			sourceTree = "<group>";
@@ -678,6 +689,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1573562F28FFA79B00EA565B /* SettingScreenViewController.swift in Sources */,
+				BCC74A812922061000582248 /* PaperTemplateSelectLength.swift in Sources */,
 				C5F26FE729183F050060109B /* TimerOfPaperViewController.swift in Sources */,
 				BCE6FEBE291B917C0093C36E /* PaperStorageClosedCollectionCell.swift in Sources */,
 				BC175412291E180D00A5F57F /* PaperTimePicker.swift in Sources */,
@@ -702,6 +714,7 @@
 				D22E4ACB28EBFDEA001091DA /* SignUpViewModel.swift in Sources */,
 				AFBF86A4291AB47D00766D9C /* BackgroundButtonViewController.swift in Sources */,
 				D2EF708F29066FA10007E611 /* DynamicLinks+Funcs.swift in Sources */,
+				BCC74A7D2922050B00582248 /* PaperSettingLength.swift in Sources */,
 				D2B6308028EE870D008365CB /* UIControl+Extensions.swift in Sources */,
 				C5F6954C28FEDCF700365719 /* UIButton+Extensions.swift in Sources */,
 				D2B6308E28F16493008365CB /* SignUpTextField.swift in Sources */,
@@ -714,6 +727,7 @@
 				D251BDC728ED29670094ECD9 /* TemplateModel.swift in Sources */,
 				AF541589291E12C100A0CBD2 /* StickerCollectionViewCell.swift in Sources */,
 				CFDA52C528F48E96006774E2 /* SidebarViewController.swift in Sources */,
+				BCC74A83292208ED00582248 /* PaperTemplateCollectionHeader.swift in Sources */,
 				C5A8D274290844030006D244 /* MagnifiedCardViewController.swift in Sources */,
 				D2B6309628F69AAB008365CB /* PaperPreviewModel.swift in Sources */,
 				D2B6308628EF0BCB008365CB /* UIFont+Extensions.swift in Sources */,
@@ -744,6 +758,7 @@
 				D22E4AA228EBDC72001091DA /* AppDelegate.swift in Sources */,
 				D22E4AA428EBDC72001091DA /* SceneDelegate.swift in Sources */,
 				BCF2481928EFC4CF008CD0F9 /* PaperSettingViewModel.swift in Sources */,
+				BCC74A7F292205A200582248 /* PaperTemplateCollectionCell.swift in Sources */,
 				D251BDBD28ED206F0094ECD9 /* UserModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/RollingPaper/RollingPaper/Components/TimerView.swift
+++ b/RollingPaper/RollingPaper/Components/TimerView.swift
@@ -9,7 +9,7 @@ import UIKit
 import SnapKit
 import Combine
 
-private class Length {
+private final class Length {
     static let timerHeight: CGFloat = 32
     static let timerWidth1: CGFloat = 172
     static let timerWidth2: CGFloat = 116

--- a/RollingPaper/RollingPaper/Components/TimerView.swift
+++ b/RollingPaper/RollingPaper/Components/TimerView.swift
@@ -34,7 +34,7 @@ class TimerView: UIStackView {
     private var endTime: Date?
     private var remainTimeState: RemainTimeState = .hour
     enum RemainTimeState {
-        case hour, minute, second
+        case hour, minute, second, end
     }
     
     override init(frame: CGRect) {
@@ -71,7 +71,7 @@ class TimerView: UIStackView {
         })
         
         time.font = .systemFont(ofSize: 16, weight: .semibold)
-        time.textAlignment = .center
+        time.textAlignment = .left
         time.textColor = UIColor.white
         time.snp.makeConstraints({ make in
             make.width.equalTo(Length.textWidth1)
@@ -87,7 +87,10 @@ class TimerView: UIStackView {
         backgroundColor = timeInterval > 60*30 ? UIColor.black.withAlphaComponent(0.32) : UIColor.red
         
         // 남은 시간에 따라 레이아웃 가로 길이 조절
-        if timeInterval >= 0 && timeInterval < 60 && remainTimeState != .second {
+        if timeInterval < 0 && remainTimeState != .end {
+            remainTimeState = .end
+            // 나중에 UI 업데이트하기
+        } else if timeInterval >= 0 && timeInterval < 60 && remainTimeState != .second {
             remainTimeState = .second
             snp.updateConstraints({ make in
                 make.width.equalTo(Length.timerWidth3)
@@ -103,7 +106,7 @@ class TimerView: UIStackView {
             time.snp.updateConstraints({ make in
                 make.width.equalTo(Length.textWidth2)
             })
-        } else if timeInterval >= 3600 && remainTimeState != .hour  {
+        } else if timeInterval >= 3600 && remainTimeState != .hour {
             remainTimeState = .hour
             snp.updateConstraints({ make in
                 make.width.equalTo(Length.timerWidth1)
@@ -113,7 +116,12 @@ class TimerView: UIStackView {
             })
         }
         
-        time.text = changeTimeFormat(second: timeInterval)
+        if timeInterval < 0 {
+            time.text = changeTimeFormat(second: 0)
+        } else {
+            time.text = changeTimeFormat(second: timeInterval)
+        }
+        
     }
     
     // 초를 특정 포맷으로 바꾸기 (00시간 00분 00초)

--- a/RollingPaper/RollingPaper/Managers/TimeFlowManager.swift
+++ b/RollingPaper/RollingPaper/Managers/TimeFlowManager.swift
@@ -1,0 +1,53 @@
+//
+//  TimeFlowManager.swift
+//  RollingPaper
+//
+//  Created by 김동락 on 2022/11/14.
+//
+
+import Combine
+import UIKit
+
+// 타이머 시간 흐르게 하는 클래스
+final class TimeFlowManager {
+    private let timerInterval = 1.0 // 1초 간격
+    private let output: PassthroughSubject<Output, Never> = .init()
+    private var cancellables = Set<AnyCancellable>()
+    private var timer: AnyCancellable?
+    enum Input {
+        case viewDidAppear
+        case viewDidDisappear
+    }
+    enum Output {
+        case timeIsUpdated
+    }
+    
+    // 타이머 연동
+    private func bindTimer() {
+        timer = Timer.publish(every: timerInterval, on: .main, in: .common)
+            .autoconnect()
+            .receive(on: DispatchQueue.global(qos: .background))
+            .sink(receiveValue: { [weak self] _ in
+                guard let self = self else {return}
+                // 타이머 업데이트 됐다고 알려주기
+                self.output.send(.timeIsUpdated)
+            })
+    }
+    
+    // 뷰가 나타나면 타이머 연결, 사라지면 타이머 해제
+    func transform(input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
+        input
+            .receive(on: DispatchQueue.global(qos: .background))
+            .sink(receiveValue: { [weak self] event in
+                guard let self = self else {return}
+                switch event {
+                case .viewDidAppear:
+                    self.bindTimer()
+                case .viewDidDisappear:
+                    self.timer?.cancel()
+                }
+            })
+            .store(in: &cancellables)
+        return output.eraseToAnyPublisher()
+    }
+}

--- a/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageClosedCollectionCell.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageClosedCollectionCell.swift
@@ -5,70 +5,61 @@
 //  Created by 김동락 on 2022/11/09.
 //
 
-import UIKit
 import SnapKit
+import UIKit
 
 // 컬렉션 뷰에 들어가는 셀들을 보여주는 뷰 (종료된거)
-class PaperStorageClosedCollectionCell: UICollectionViewCell {
+final class PaperStorageClosedCollectionCell: UICollectionViewCell {
     static let identifier = "ClosedCollectionCell"
+    
+    // 셀 전체를 나타내는 뷰
     private let cell = UIView()
-    private let preview = UIImageView()
-    private let previewOverlay = UIView()
-    private let label = UIStackView()
-    private let title = UILabel()
-    private let date = UILabel()
+    // 페이퍼 썸네일 이미지가 들어가는 프리뷰
+    private lazy var preview: UIImageView = {
+        let preview = UIImageView()
+        preview.layer.masksToBounds = true
+        preview.layer.cornerRadius = PaperStorageLength.paperThumbnailCornerRadius
+        preview.contentMode = .scaleAspectFill
+        return preview
+    }()
+    // 프리뷰에 덮어씌우는 투명한 검은 배경
+    private let previewOverlay: UIView = {
+        let previewOverlay = UIView()
+        previewOverlay.backgroundColor = UIColor.black.withAlphaComponent(0.25)
+        return previewOverlay
+    }()
+    // 페이퍼에 들어가는 글자들 포함하는 스택
+    private let label: UIStackView = {
+        let label = UIStackView()
+        label.axis = .vertical
+        label.spacing = PaperStorageLength.labelSpacing
+        return label
+    }()
+    // 페이퍼 제목
+    private let title: UILabel = {
+        let title = UILabel()
+        title.font = .preferredFont(for: .largeTitle, weight: .semibold)
+        title.textColor = UIColor.white
+        title.textAlignment = .center
+        return title
+    }()
+    // 페이퍼 종료 날짜
+    private let date: UILabel = {
+        let date = UILabel()
+        date.font = .preferredFont(for: .subheadline, weight: .bold)
+        date.textColor = UIColor.white
+        date.textAlignment = .center
+        return date
+    }()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         configure()
+        setConstraints()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-    
-    private func configure() {
-        addSubview(cell)
-        cell.addSubview(preview)
-        cell.addSubview(label)
-        preview.addSubview(previewOverlay)
-        label.addArrangedSubview(title)
-        label.addArrangedSubview(date)
-        
-        cell.snp.makeConstraints({ make in
-            make.edges.equalToSuperview()
-        })
-        
-        preview.layer.masksToBounds = true
-        preview.layer.cornerRadius = PaperStorageLength.paperThumbnailCornerRadius
-        preview.contentMode = .scaleAspectFill
-        preview.snp.makeConstraints({ make in
-            make.top.equalToSuperview()
-            make.leading.equalToSuperview()
-            make.width.equalTo(PaperStorageLength.closedPaperThumbnailWidth)
-            make.height.equalTo(PaperStorageLength.closedPaperThumbnailHeight)
-        })
-        
-        previewOverlay.backgroundColor = UIColor.black.withAlphaComponent(0.25)
-        previewOverlay.snp.makeConstraints({ make in
-            make.edges.equalToSuperview()
-        })
-        
-        label.axis = .vertical
-        label.spacing = PaperStorageLength.labelSpacing
-        label.snp.makeConstraints({ make in
-            make.centerX.equalTo(preview)
-            make.centerY.equalTo(preview)
-        })
-        
-        title.font = .preferredFont(for: .largeTitle, weight: .semibold)
-        title.textColor = UIColor.white
-        title.textAlignment = .center
-        
-        date.font = .preferredFont(for: .subheadline, weight: .bold)
-        date.textColor = UIColor.white
-        date.textAlignment = .center
-        
     }
     
     // 날짜를 2022.10.13 같은 형식으로 바꾸기
@@ -78,6 +69,7 @@ class PaperStorageClosedCollectionCell: UICollectionViewCell {
         return dateFormatter.string(from: date)
     }
     
+    // 해당되는 셀 설정하기
     func setCell(paper: PaperPreviewModel?, thumbnail: UIImage?) {
         if let paper = paper {
             date.text = changeDateFormat(date: paper.endTime)
@@ -91,5 +83,36 @@ class PaperStorageClosedCollectionCell: UICollectionViewCell {
         } else {
             isHidden = true
         }
+    }
+}
+
+// 스냅킷 설정
+extension PaperStorageClosedCollectionCell {
+    private func configure() {
+        addSubview(cell)
+        cell.addSubview(preview)
+        cell.addSubview(label)
+        preview.addSubview(previewOverlay)
+        label.addArrangedSubview(title)
+        label.addArrangedSubview(date)
+    }
+    
+    private func setConstraints() {
+        cell.snp.makeConstraints({ make in
+            make.edges.equalToSuperview()
+        })
+        preview.snp.makeConstraints({ make in
+            make.top.equalToSuperview()
+            make.leading.equalToSuperview()
+            make.width.equalTo(PaperStorageLength.closedPaperThumbnailWidth)
+            make.height.equalTo(PaperStorageLength.closedPaperThumbnailHeight)
+        })
+        previewOverlay.snp.makeConstraints({ make in
+            make.edges.equalToSuperview()
+        })
+        label.snp.makeConstraints({ make in
+            make.centerX.equalTo(preview)
+            make.centerY.equalTo(preview)
+        })
     }
 }

--- a/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageCollectionHeader.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageCollectionHeader.swift
@@ -5,34 +5,45 @@
 //  Created by 김동락 on 2022/11/09.
 //
 
-import UIKit
 import SnapKit
+import UIKit
 
 // 컬렉션 뷰에서 섹션의 제목을 보여주는 뷰
-class PaperStorageCollectionHeader: UICollectionReusableView {
+final class PaperStorageCollectionHeader: UICollectionReusableView {
     static let identifier = "CollectionHeader"
-    private let title = UILabel()
+    
+    private lazy var title: UILabel = {
+        let title = UILabel()
+        title.font = .preferredFont(forTextStyle: .title2)
+        return title
+    }()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         configure()
+        setConstraints()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // 헤더 제목 설정하기
+    func setHeader(text: String) {
+        title.text = text
+    }
+}
+
+// 스냅킷 설정
+extension PaperStorageCollectionHeader {
     private func configure() {
         addSubview(title)
-        
-        title.font = .preferredFont(forTextStyle: .title2)
+    }
+    
+    private func setConstraints() {
         title.snp.makeConstraints({ make in
             make.top.equalToSuperview()
             make.leading.equalToSuperview().offset(PaperStorageLength.headerLeftMargin)
         })
-    }
-    
-    func setHeader(text: String) {
-        title.text = text
     }
 }

--- a/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageFlowLayout.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageFlowLayout.swift
@@ -7,9 +7,10 @@
 
 import UIKit
 
-class PaperStorageFlowLayout: UICollectionViewFlowLayout {
-    let cellHorizontalSpacing: CGFloat
-    let inset: UIEdgeInsets
+// 컬렉션뷰에 쓰이는 레이아웃
+final class PaperStorageFlowLayout: UICollectionViewFlowLayout {
+    private let cellHorizontalSpacing: CGFloat
+    private let inset: UIEdgeInsets
 
     init(cellSpacing: CGFloat, inset: UIEdgeInsets) {
         self.cellHorizontalSpacing = cellSpacing
@@ -21,6 +22,7 @@ class PaperStorageFlowLayout: UICollectionViewFlowLayout {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // 컬렉션 뷰의 셀들 일정한 간격으로 나열되도록 하기
     override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
         sectionInset = inset
         

--- a/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageLength.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageLength.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class PaperStorageLength {
+final class PaperStorageLength {
     static let paperThumbnailCornerRadius: CGFloat = 12
     static let headerWidth: CGFloat = 200 // 임시
     static let headerHeight: CGFloat = 29

--- a/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageOpenedCollectionCell.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageOpenedCollectionCell.swift
@@ -5,70 +5,53 @@
 //  Created by 김동락 on 2022/11/09.
 //
 
-import UIKit
-import SnapKit
 import Combine
+import SnapKit
+import UIKit
 
 // 컬렉션 뷰에 들어가는 셀들을 보여주는 뷰 (진행중인거)
-class PaperStorageOpenedCollectionCell: UICollectionViewCell {
+final class PaperStorageOpenedCollectionCell: UICollectionViewCell {
     static let identifier = "OpenedCollectionCell"
     private var cancellables = Set<AnyCancellable>()
+    
+    // 셀 전체를 나타내는 뷰
     private let cell = UIView()
-    private let preview = UIImageView()
-    private let previewOverlay = UIView()
+    // 페이퍼의 남은 시간을 보여주는 타이머
     private let timer = TimerView()
-    private let title = UILabel()
+    // 페이퍼 썸네일 이미지가 들어가는 프리뷰
+    private lazy var preview: UIImageView = {
+        let preview = UIImageView()
+        preview.layer.masksToBounds = true
+        preview.layer.cornerRadius = PaperStorageLength.paperThumbnailCornerRadius
+        preview.contentMode = .scaleAspectFill
+        return preview
+    }()
+    // 프리뷰에 덮어씌우는 투명한 검은 배경
+    private lazy var previewOverlay: UIView = {
+        let previewOverlay = UIView()
+        previewOverlay.backgroundColor = UIColor.black.withAlphaComponent(0.25)
+        return previewOverlay
+    }()
+    // 페이퍼 제목
+    private lazy var title: UILabel = {
+        let title = UILabel()
+        title.font = .preferredFont(for: .title1, weight: .semibold)
+        title.textColor = UIColor.white
+        title.textAlignment = .right
+        return title
+    }()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         configure()
+        setConstraints()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    private func configure() {
-        addSubview(cell)
-        cell.addSubview(preview)
-        cell.addSubview(timer)
-        cell.addSubview(title)
-        preview.addSubview(previewOverlay)
-        
-        cell.snp.makeConstraints({ make in
-            make.edges.equalToSuperview()
-        })
-        
-        preview.layer.masksToBounds = true
-        preview.layer.cornerRadius = PaperStorageLength.paperThumbnailCornerRadius
-        preview.contentMode = .scaleAspectFill
-        preview.snp.makeConstraints({ make in
-            make.top.equalToSuperview()
-            make.leading.equalToSuperview()
-            make.width.equalTo(PaperStorageLength.openedPaperThumbnailWidth)
-            make.height.equalTo(PaperStorageLength.openedPaperThumbnailHeight)
-        })
-        
-        previewOverlay.backgroundColor = UIColor.black.withAlphaComponent(0.25)
-        previewOverlay.snp.makeConstraints({ make in
-            make.edges.equalToSuperview()
-        })
-        
-        title.font = .preferredFont(for: .title1, weight: .semibold)
-        title.textColor = UIColor.white
-        title.textAlignment = .right
-        title.snp.makeConstraints({ make in
-            make.bottom.equalTo(preview.snp.bottom).offset(-PaperStorageLength.openedPaperTitleBottomMargin)
-            make.trailing.equalTo(preview.snp.trailing).offset(-PaperStorageLength.openedPaperTitleRightMargin)
-            make.leading.equalTo(preview.snp.leading).offset(PaperStorageLength.openedPaperTitleLeftMargin)
-        })
-        
-        timer.snp.makeConstraints({ make in
-            make.top.equalTo(preview.snp.top).offset(PaperStorageLength.timerTopMargin)
-            make.leading.equalTo(preview.snp.leading).offset(PaperStorageLength.timerLeftMargin)
-        })
-    }
-    
+    // 해당되는 셀 설정하기
     func setCell(paper: PaperPreviewModel, thumbnail: UIImage?, now: Date) {
         timer.setEndTime(time: paper.endTime)
         title.text = paper.title
@@ -76,6 +59,41 @@ class PaperStorageOpenedCollectionCell: UICollectionViewCell {
         preview.snp.updateConstraints({ make in
             make.width.equalTo(PaperStorageLength.openedPaperThumbnailWidth)
             make.height.equalTo(PaperStorageLength.openedPaperThumbnailHeight)
+        })
+    }
+}
+
+// 스냅킷 설정
+extension PaperStorageOpenedCollectionCell {
+    private func configure() {
+        addSubview(cell)
+        cell.addSubview(preview)
+        cell.addSubview(timer)
+        cell.addSubview(title)
+        preview.addSubview(previewOverlay)
+    }
+    
+    private func setConstraints() {
+        cell.snp.makeConstraints({ make in
+            make.edges.equalToSuperview()
+        })
+        preview.snp.makeConstraints({ make in
+            make.top.equalToSuperview()
+            make.leading.equalToSuperview()
+            make.width.equalTo(PaperStorageLength.openedPaperThumbnailWidth)
+            make.height.equalTo(PaperStorageLength.openedPaperThumbnailHeight)
+        })
+        previewOverlay.snp.makeConstraints({ make in
+            make.edges.equalToSuperview()
+        })
+        title.snp.makeConstraints({ make in
+            make.bottom.equalTo(preview.snp.bottom).offset(-PaperStorageLength.openedPaperTitleBottomMargin)
+            make.trailing.equalTo(preview.snp.trailing).offset(-PaperStorageLength.openedPaperTitleRightMargin)
+            make.leading.equalTo(preview.snp.leading).offset(PaperStorageLength.openedPaperTitleLeftMargin)
+        })
+        timer.snp.makeConstraints({ make in
+            make.top.equalTo(preview.snp.top).offset(PaperStorageLength.timerTopMargin)
+            make.leading.equalTo(preview.snp.leading).offset(PaperStorageLength.timerLeftMargin)
         })
     }
 }

--- a/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageViewController.swift
@@ -5,17 +5,16 @@
 //  Created by 김동락 on 2022/10/12.
 //
 
-import UIKit
-import SnapKit
 import Combine
+import SnapKit
+import UIKit
 
-class PaperStorageViewController: UIViewController {
+final class PaperStorageViewController: UIViewController {
     private let splitViewManager = SplitViewManager.shared
     private let viewModel = PaperStorageViewModel()
-    private let spinner = UIActivityIndicatorView()
     private let input: PassthroughSubject<PaperStorageViewModel.Input, Never> = .init()
+    
     private var cancellables = Set<AnyCancellable>()
-    private var paperCollectionView: PaperStorageCollectionView?
     private var splitViewIsOpened: Bool = true
     private var viewIsChange: Bool = false
     private var dataState: DataState = .nothing
@@ -24,15 +23,41 @@ class PaperStorageViewController: UIViewController {
         case nothing, onlyOpened, onlyClosed, both
     }
     
+    // 데이터 로딩시 보여줄 스피너
+    private lazy var spinner: UIActivityIndicatorView = {
+        let spinner = UIActivityIndicatorView()
+        spinner.color = .label
+        return spinner
+    }()
+    // 페이퍼 목록 보여주는 컬렉션뷰
+    private lazy var paperCollectionView: PaperStorageCollectionView = {
+        let paperCollectionView = PaperStorageCollectionView(frame: .zero, collectionViewLayout: .init())
+        paperCollectionView.setCollectionViewLayout(getCollectionViewLayout(), animated: false)
+ 
+        paperCollectionView.backgroundColor = .systemBackground
+        paperCollectionView.alwaysBounceVertical = true
+
+        paperCollectionView.register(PaperStorageOpenedCollectionCell.self, forCellWithReuseIdentifier: PaperStorageOpenedCollectionCell.identifier)
+        paperCollectionView.register(PaperStorageClosedCollectionCell.self, forCellWithReuseIdentifier: PaperStorageClosedCollectionCell.identifier)
+        paperCollectionView.register(PaperStorageCollectionHeader.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: PaperStorageCollectionHeader.identifier)
+        
+        paperCollectionView.dataSource = self
+        paperCollectionView.delegate = self
+        paperCollectionView.isHidden = true
+        
+        return paperCollectionView
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         bind()
         splitViewBind()
         setMainView()
-        setSpinnerView()
-        setCollectionView()
+        configure()
+        setConstraints()
     }
     
+    // splitview 나오게 하기
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.splitViewController?.show(.primary)
@@ -49,7 +74,7 @@ class PaperStorageViewController: UIViewController {
     // 뷰모델한테 뷰 사라졌다고 알려주기
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        paperCollectionView?.isHidden = true
+        paperCollectionView.isHidden = true
         input.send(.viewDidDisappear)
     }
     
@@ -61,32 +86,19 @@ class PaperStorageViewController: UIViewController {
             .sink(receiveValue: { [weak self] event in
                 guard let self = self else {return}
                 switch event {
-                // 페이퍼에 변화가 있으면 UI 업데이트 하기
+                // 변화가 있으면 UI 업데이트 하기
                 case .initPapers:
                     self.updateLoadingView(isLoading: false)
                 case .papersAreUpdatedByTimer, .papersAreUpdatedInDatabase:
                     break
                 }
                 self.setDataState()
-                self.paperCollectionView?.reloadData()
+                self.paperCollectionView.reloadData()
             })
             .store(in: &cancellables)
     }
     
-    // 진행중인거, 종료된거에 따라 상태 변경하기
-    private func setDataState() {
-        if viewModel.openedPapers.isEmpty && viewModel.closedPapers.isEmpty {
-            dataState = .nothing
-        } else if viewModel.openedPapers.isEmpty {
-            dataState = .onlyClosed
-        } else if viewModel.closedPapers.isEmpty {
-            dataState = .onlyOpened
-        } else {
-            dataState = .both
-        }
-    }
-    
-    // splitView에 대한 어떤 행동을 받고 그에 따라 어떤 행동을 할지 정하기
+    // splitView가 열리고 닫힘에 따라 어떤 행동을 할지 정하기
     private func splitViewBind() {
         viewIsChange = false
         let output = splitViewManager.getOutput()
@@ -107,80 +119,61 @@ class PaperStorageViewController: UIViewController {
             .store(in: &cancellables)
     }
     
-    // 스플릿뷰 열고닫음에 따라 뷰 업데이트하기
+    // 메인 뷰 초기화
+    private func setMainView() {
+        view.backgroundColor = .systemBackground
+    }
+    
+    // 진행중인거, 종료된거에 따라 데이터 상태 변경하기
+    private func setDataState() {
+        if viewModel.openedPapers.isEmpty && viewModel.closedPapers.isEmpty {
+            dataState = .nothing
+        } else if viewModel.openedPapers.isEmpty {
+            dataState = .onlyClosed
+        } else if viewModel.closedPapers.isEmpty {
+            dataState = .onlyOpened
+        } else {
+            dataState = .both
+        }
+    }
+    
+    // 컬렉션 뷰 셀의 가로 길이 업데이트하기
     private func updateLayout() {
         let multiplyVal = splitViewIsOpened ? 0.75 : 1.0
         PaperStorageLength.openedPaperThumbnailWidth = (UIScreen.main.bounds.width*multiplyVal-(PaperStorageLength.sectionLeftMargin+PaperStorageLength.sectionRightMargin+PaperStorageLength.openedCellHorizontalSpace+2))/2
         PaperStorageLength.closedPaperThumbnailWidth = (UIScreen.main.bounds.width*multiplyVal-(PaperStorageLength.sectionLeftMargin+PaperStorageLength.sectionRightMargin))
         
-        UIView.performWithoutAnimation({
-            let openedIndexPath = Array(0..<viewModel.openedPapers.count).map({ IndexPath(item: $0, section: 0) })
-            self.paperCollectionView?.reloadItems(at: openedIndexPath)
-            self.paperCollectionView?.reloadSections(IndexSet(integer: 1))
+        UIView.performWithoutAnimation({ [weak self] in
+            guard let self = self else {return}
+            let openedIndexPath = Array(0..<self.viewModel.openedPapers.count).map({ IndexPath(item: $0, section: 0) })
+            self.paperCollectionView.reloadItems(at: openedIndexPath)
+            self.paperCollectionView.reloadSections(IndexSet(integer: 1))
         })
     }
     
     // 로딩뷰 띄워주거나 없애기
     private func updateLoadingView(isLoading: Bool) {
         if isLoading {
-            paperCollectionView?.isHidden = true
+            paperCollectionView.isHidden = true
             spinner.isHidden = false
             spinner.startAnimating()
         } else {
             DispatchQueue.main.asyncAfter(deadline: .now()+0.5) { [weak self] in
                 guard let self = self else {return}
-                self.paperCollectionView?.isHidden = false
+                self.paperCollectionView.isHidden = false
                 self.spinner.isHidden = true
                 self.spinner.stopAnimating()
             }
         }
     }
     
-    // 메인 뷰 초기화
-    private func setMainView() {
-        view.backgroundColor = .systemBackground
-    }
-    
-    // 스피너 뷰 초기화
-    private func setSpinnerView() {
-        spinner.color = .label
-        
-        view.addSubview(spinner)
-        spinner.snp.makeConstraints({ make in
-            make.edges.equalToSuperview()
-        })
-    }
-    
-    // 컬렉션 뷰 레이아웃 초기화
-    private func setCollectionViewLayout() {
+    // 컬렉션 뷰 레이아웃 가져오기
+    private func getCollectionViewLayout() -> PaperStorageFlowLayout {
         let sectionInset = UIEdgeInsets(top: PaperStorageLength.sectionTopMargin, left: PaperStorageLength.sectionLeftMargin, bottom: PaperStorageLength.sectionBottomMargin, right: PaperStorageLength.sectionRightMargin)
-        let collectionViewLayer = PaperStorageFlowLayout(cellSpacing: PaperStorageLength.openedCellHorizontalSpace, inset: sectionInset)
-        collectionViewLayer.headerReferenceSize = .init(width: PaperStorageLength.headerWidth, height: PaperStorageLength.headerHeight)
-        collectionViewLayer.estimatedItemSize = UICollectionViewFlowLayout.automaticSize
-        self.paperCollectionView?.setCollectionViewLayout(collectionViewLayer, animated: false)
-    }
-    
-    // 컬렉션 뷰 초기화
-    private func setCollectionView() {
-        paperCollectionView = PaperStorageCollectionView(frame: .zero, collectionViewLayout: .init())
-        setCollectionViewLayout()
-        
-        guard let collectionView = paperCollectionView else {return}
-        collectionView.backgroundColor = .systemBackground
-        collectionView.alwaysBounceVertical = true
-
-        collectionView.register(PaperStorageOpenedCollectionCell.self, forCellWithReuseIdentifier: PaperStorageOpenedCollectionCell.identifier)
-        collectionView.register(PaperStorageClosedCollectionCell.self, forCellWithReuseIdentifier: PaperStorageClosedCollectionCell.identifier)
-        collectionView.register(PaperStorageCollectionHeader.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: PaperStorageCollectionHeader.identifier)
-        collectionView.dataSource = self
-        collectionView.delegate = self
-        collectionView.isHidden = true
-
-        view.addSubview(collectionView)
-        collectionView.snp.makeConstraints({ make in
-            make.leading.trailing.bottom.equalToSuperview()
-            make.top.equalTo(view.safeAreaLayoutGuide)
-        })
+        let collectionViewLayout = PaperStorageFlowLayout(cellSpacing: PaperStorageLength.openedCellHorizontalSpace, inset: sectionInset)
+        collectionViewLayout.headerReferenceSize = .init(width: PaperStorageLength.headerWidth, height: PaperStorageLength.headerHeight)
+        collectionViewLayout.estimatedItemSize = UICollectionViewFlowLayout.automaticSize
+        return collectionViewLayout
     }
     
     // 특정 페이퍼를 선택하면 알려주기
@@ -263,5 +256,23 @@ extension PaperStorageViewController: UICollectionViewDelegate, UICollectionView
     }
 }
 
+// 스냅킷 설정
+extension PaperStorageViewController {
+    private func configure() {
+        view.addSubview(spinner)
+        view.addSubview(paperCollectionView)
+    }
+    
+    private func setConstraints() {
+        spinner.snp.makeConstraints({ make in
+            make.edges.equalToSuperview()
+        })
+        paperCollectionView.snp.makeConstraints({ make in
+            make.leading.trailing.bottom.equalToSuperview()
+            make.top.equalTo(view.safeAreaLayoutGuide)
+        })
+    }
+}
+
 // 진행중인 페이퍼와 종료된 페이퍼들을 모두 보여주는 컬렉션 뷰
-private class PaperStorageCollectionView: UICollectionView {}
+final private class PaperStorageCollectionView: UICollectionView {}

--- a/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageViewController.swift
@@ -62,11 +62,13 @@ class PaperStorageViewController: UIViewController {
                 guard let self = self else {return}
                 switch event {
                 // 페이퍼에 변화가 있으면 UI 업데이트 하기
-                case .initPapers, .papersAreUpdatedInDatabase, .papersAreUpdatedByTimer:
-                    self.paperCollectionView?.reloadData()
-                    self.setDataState()
+                case .initPapers:
                     self.updateLoadingView(isLoading: false)
+                case .papersAreUpdatedByTimer, .papersAreUpdatedInDatabase:
+                    break
                 }
+                self.setDataState()
+                self.paperCollectionView?.reloadData()
             })
             .store(in: &cancellables)
     }

--- a/RollingPaper/RollingPaper/ViewControllers/Core/PaperTemplate/PaperSettingLength.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/PaperTemplate/PaperSettingLength.swift
@@ -1,0 +1,37 @@
+//
+//  PaperSettingLength.swift
+//  RollingPaper
+//
+//  Created by 김동락 on 2022/11/14.
+//
+
+import UIKit
+
+final class PaperSettingLength {
+    static let topMargin: CGFloat = 48
+    static let thumbnailLeftMargin: CGFloat = 48
+    static let thumbnailRadius: CGFloat = 24
+    static let thumbnailWidth: CGFloat = 262
+    static let thumbnailHeight: CGFloat = 388
+    static let thumbnailLeftPadding: CGFloat = 24
+    static let thumbnailRightPadding: CGFloat = 24
+    static let thumbnailBottomPadding: CGFloat = 28
+    static let thumbnailLabelSpacing: CGFloat = 8
+    static let sectionLeftMargin: CGFloat = 36
+    static let sectionRightMargin: CGFloat = 88
+    static let sectionTitleBottomMargin: CGFloat = 14
+    static let sectionSubTitleBottomMargin: CGFloat = 32
+    static let sectionSpacing: CGFloat = 48
+    static let textfieldHeight: CGFloat = 15
+    static let textfieldWithBorderSpacing: CGFloat = 9
+    static let textfieldBorderWidth: CGFloat = 2
+    static let textfieldWithBorderHeight: CGFloat = textfieldHeight + textfieldWithBorderSpacing + textfieldBorderWidth
+    static let textfieldTitleLengthSpacing: CGFloat = 10
+    static let titleLengthLabelWidth: CGFloat = 60
+    static let titleLengthLabelHeight: CGFloat = 28
+    static let warningLabelTopMargin: CGFloat = 10
+    static let timePickerLeftMargin: CGFloat = 18
+    static let timePickerButtonWidth: CGFloat = 120
+    static let timePickerButtonHeight: CGFloat = 36
+    static let timePickerButtonRadius: CGFloat = 6
+}

--- a/RollingPaper/RollingPaper/ViewControllers/Core/PaperTemplate/PaperTemplateCollectionCell.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/PaperTemplate/PaperTemplateCollectionCell.swift
@@ -1,0 +1,78 @@
+//
+//  PaperTemplateCollectionCell.swift
+//  RollingPaper
+//
+//  Created by 김동락 on 2022/11/14.
+//
+
+import UIKit
+
+// 컬렉션 뷰에 들어가는 셀들을 보여주는 뷰
+final class PaperTemplateCollectionCell: UICollectionViewCell {
+    static let identifier = "CollectionCell"
+    
+    // 셀 전체를 나타내는 뷰
+    private lazy var cell: UIStackView = {
+        let cell = UIStackView()
+        cell.spacing = PaperTemplateSelectLength.templateTitleTopMargin
+        cell.axis = .vertical
+        return cell
+    }()
+    // 템플릿 제목
+    private lazy var title: UILabel = {
+        let title = UILabel()
+        title.font = .preferredFont(forTextStyle: .body)
+        title.textColor = UIColor(rgb: 0x808080)
+        title.textAlignment = .center
+        return title
+    }()
+    // 템플릿 썸네일
+    private lazy var imageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.layer.masksToBounds = true
+        imageView.layer.cornerRadius = PaperTemplateSelectLength.templateThumbnailCornerRadius
+        imageView.contentMode = .scaleAspectFill
+        return imageView
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+        setConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // 해당되는 셀 설정하기
+    func setCell(template: TemplateModel) {
+        imageView.image = template.thumbnail
+        title.text = template.templateString
+    }
+}
+
+// 스냅킷 설정
+extension PaperTemplateCollectionCell {
+    private func configure() {
+        addSubview(cell)
+        cell.addArrangedSubview(imageView)
+        cell.addArrangedSubview(title)
+    }
+    
+    private func setConstraints() {
+        cell.snp.makeConstraints({ make in
+            make.edges.equalToSuperview()
+        })
+        imageView.snp.makeConstraints({ make in
+            make.top.equalToSuperview()
+            make.leading.equalToSuperview()
+            make.width.equalTo(PaperTemplateSelectLength.templateThumbnailWidth)
+            make.height.equalTo(PaperTemplateSelectLength.templateThumbnailHeight)
+        })
+        title.snp.makeConstraints({ make in
+            make.centerX.equalTo(imageView)
+            make.width.equalToSuperview()
+        })
+    }
+}

--- a/RollingPaper/RollingPaper/ViewControllers/Core/PaperTemplate/PaperTemplateCollectionHeader.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/PaperTemplate/PaperTemplateCollectionHeader.swift
@@ -1,0 +1,49 @@
+//
+//  PaperTemplateCollectionHeader.swift
+//  RollingPaper
+//
+//  Created by 김동락 on 2022/11/14.
+//
+
+import UIKit
+
+// 컬렉션 뷰에서 섹션의 제목을 보여주는 뷰
+final class PaperTemplateCollectionHeader: UICollectionReusableView {
+    static let identifier = "CollectionHeader"
+    
+    // 헤더 제목
+    private lazy var title: UILabel = {
+        let title = UILabel()
+        title.font = .preferredFont(forTextStyle: .title2)
+        return title
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+        setConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // 헤더 제목 설정하기
+    func setHeader(text: String) {
+        title.text = text
+    }
+}
+
+// 스냅킷 설정
+extension PaperTemplateCollectionHeader {
+    private func configure() {
+        addSubview(title)
+    }
+    
+    private func setConstraints() {
+        title.snp.makeConstraints({ make in
+            make.top.equalToSuperview()
+            make.leading.equalToSuperview().offset(PaperTemplateSelectLength.headerLeftMargin)
+        })
+    }
+}

--- a/RollingPaper/RollingPaper/ViewControllers/Core/PaperTemplate/PaperTemplateSelectLength.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/PaperTemplate/PaperTemplateSelectLength.swift
@@ -1,0 +1,27 @@
+//
+//  PaperTemplateSelectLength.swift
+//  RollingPaper
+//
+//  Created by 김동락 on 2022/11/14.
+//
+
+import UIKit
+
+final class PaperTemplateSelectLength {
+    static let templateThumbnailWidth: CGFloat = (UIScreen.main.bounds.width*0.75-(24*5))/4
+    static let templateThumbnailHeight: CGFloat = templateThumbnailWidth*0.75
+    static let templateThumbnailCornerRadius: CGFloat = 12
+    static let templateTitleHeight: CGFloat = 19
+    static let templateTitleTopMargin: CGFloat = 16
+    static let cellWidth: CGFloat = templateThumbnailWidth
+    static let cellHeight: CGFloat = templateThumbnailHeight + templateTitleTopMargin + templateTitleHeight
+    static let cellHorizontalSpace: CGFloat = 20
+    static let cellVerticalSpace: CGFloat = 28
+    static let sectionTopMargin: CGFloat = 28
+    static let sectionBottomMargin: CGFloat = 48
+    static let sectionRightMargin: CGFloat = 28
+    static let sectionLeftMargin: CGFloat = 28
+    static let headerWidth: CGFloat = 116
+    static let headerHeight: CGFloat = 29
+    static let headerLeftMargin: CGFloat = 34
+}

--- a/RollingPaper/RollingPaper/ViewControllers/Core/PaperTemplate/PaperTemplateSelectViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/PaperTemplate/PaperTemplateSelectViewController.swift
@@ -9,37 +9,42 @@ import UIKit
 import SnapKit
 import Combine
 
-private class Length {
-    static let templateThumbnailWidth: CGFloat = (UIScreen.main.bounds.width*0.75-(24*5))/4
-    static let templateThumbnailHeight: CGFloat = templateThumbnailWidth*0.75
-    static let templateThumbnailCornerRadius: CGFloat = 12
-    static let templateTitleHeight: CGFloat = 19
-    static let templateTitleTopMargin: CGFloat = 16
-    static let cellWidth: CGFloat = templateThumbnailWidth
-    static let cellHeight: CGFloat = templateThumbnailHeight + templateTitleTopMargin + templateTitleHeight
-    static let cellHorizontalSpace: CGFloat = 20
-    static let cellVerticalSpace: CGFloat = 28
-    static let sectionTopMargin: CGFloat = 28
-    static let sectionBottomMargin: CGFloat = 48
-    static let sectionRightMargin: CGFloat = 28
-    static let sectionLeftMargin: CGFloat = 28
-    static let headerWidth: CGFloat = 116
-    static let headerHeight: CGFloat = 29
-    static let headerLeftMargin: CGFloat = 34
-}
-
 class PaperTemplateSelectViewController: UIViewController {
     private let splitViewManager = SplitViewManager.shared
     private let viewModel = PaperTemplateSelectViewModel()
-    private let spinner = UIActivityIndicatorView()
     private let input: PassthroughSubject<PaperTemplateSelectViewModel.Input, Never> = .init()
     private var cancellables = Set<AnyCancellable>()
     private var recentTemplate: TemplateEnum?
-    private var templateCollectionView: PaperTemplateCollectionView?
+    private var isLoading: Bool = true
     private var isRecentExist: Bool {
         return recentTemplate == nil ? false : true
     }
     
+    // 데이터 로딩시 보여줄 스피너
+    private lazy var spinner: UIActivityIndicatorView = {
+        let spinner = UIActivityIndicatorView()
+        spinner.color = .label
+        return spinner
+    }()
+    // 템플릿 목록 보여주는 컬렉션뷰
+    private lazy var templateCollectionView: PaperTemplateCollectionView = {
+        let templateCollectionView = PaperTemplateCollectionView(frame: .zero, collectionViewLayout: .init())
+        templateCollectionView.setCollectionViewLayout(getCollectionViewLayout(), animated: false)
+        
+        templateCollectionView.backgroundColor = .systemBackground
+        templateCollectionView.alwaysBounceVertical = true
+        
+        templateCollectionView.register(PaperTemplateCollectionCell.self, forCellWithReuseIdentifier: PaperTemplateCollectionCell.identifier)
+        templateCollectionView.register(PaperTemplateCollectionHeader.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: PaperTemplateCollectionHeader.identifier)
+        
+        templateCollectionView.dataSource = self
+        templateCollectionView.delegate = self
+        templateCollectionView.isHidden = true
+        
+        return templateCollectionView
+    }()
+    
+    // splitview 나오게 하기
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.splitViewController?.show(.primary)
@@ -47,23 +52,18 @@ class PaperTemplateSelectViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        updateLoadingView()
         bind()
         splitViewBind()
         setMainView()
-        setSpinnerView()
-        setCollectionView()
+        configure()
+        setConstraints()
     }
     
     // view가 나타날때마다 최근 템플릿 확인하기 위해 input에 값 설정하기
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        updateLoadingView(isLoading: true)
         input.send(.viewDidAppear)
-    }
-    
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        templateCollectionView?.isHidden = true
     }
     
     // Input이 설정될때마다 자동으로 transform 함수가 실행되고 그 결과값으로 Output이 오면 어떤 행동을 할지 정하기
@@ -74,13 +74,17 @@ class PaperTemplateSelectViewController: UIViewController {
             .sink(receiveValue: { [weak self] event in
                 guard let self = self else {return}
                 switch event {
+                // 최근 템플릿 설정하기
                 case .getRecentTemplateSuccess(let template):
                     self.recentTemplate = template
                 case .getRecentTemplateFail:
                     self.recentTemplate = nil
                 }
-                self.templateCollectionView?.reloadData()
-                self.updateLoadingView(isLoading: false)
+                self.templateCollectionView.reloadData()
+                if !self.isLoading {
+                    self.updateLoadingView()
+                }
+                
             })
             .store(in: &cancellables)
     }
@@ -90,7 +94,8 @@ class PaperTemplateSelectViewController: UIViewController {
         let output = splitViewManager.getOutput()
         output
             .receive(on: DispatchQueue.main)
-            .sink(receiveValue: { event in
+            .sink(receiveValue: { [weak self] event in
+                guard let self = self else {return}
                 var extraLeftMargin: Int
                 var extraRightMargin: Int
                 switch event {
@@ -101,11 +106,12 @@ class PaperTemplateSelectViewController: UIViewController {
                     extraLeftMargin = 54
                     extraRightMargin = 24
                 }
-                self.templateCollectionView?.snp.updateConstraints({ make in
+                self.templateCollectionView.snp.updateConstraints({ make in
                     make.leading.equalToSuperview().offset(extraLeftMargin)
                     make.trailing.equalToSuperview().offset(extraRightMargin)
                 })
-                UIView.animate(withDuration: 0.5, delay: 0, animations: {
+                UIView.animate(withDuration: 0.5, delay: 0, animations: { [weak self] in
+                    guard let self = self else {return}
                     self.view.layoutIfNeeded()
                 })
             })
@@ -113,19 +119,20 @@ class PaperTemplateSelectViewController: UIViewController {
     }
     
     // 로딩뷰 띄워주거나 없애기
-    private func updateLoadingView(isLoading: Bool) {
+    private func updateLoadingView() {
         if isLoading {
-            templateCollectionView?.isHidden = true
+            templateCollectionView.isHidden = true
             spinner.isHidden = false
             spinner.startAnimating()
         } else {
             DispatchQueue.main.asyncAfter(deadline: .now()+0.3) { [weak self] in
                 guard let self = self else {return}
-                self.templateCollectionView?.isHidden = false
+                self.templateCollectionView.isHidden = false
                 self.spinner.isHidden = true
                 self.spinner.stopAnimating()
             }
         }
+        isLoading.toggle()
     }
     
     // 메인 뷰 초기화
@@ -133,45 +140,14 @@ class PaperTemplateSelectViewController: UIViewController {
         view.backgroundColor = .systemBackground
     }
     
-    // 스피너 뷰 초기화
-    private func setSpinnerView() {
-        spinner.color = .label
-        
-        view.addSubview(spinner)
-        spinner.snp.makeConstraints({ make in
-            make.edges.equalToSuperview()
-        })
-    }
-    
     // 컬렉션 뷰 레이아웃 초기화
-    private func setCollectionViewLayout() {
+    private func getCollectionViewLayout() -> UICollectionViewFlowLayout {
         let collectionViewLayer = UICollectionViewFlowLayout()
-        collectionViewLayer.sectionInset = UIEdgeInsets(top: Length.sectionTopMargin, left: Length.sectionLeftMargin, bottom: Length.sectionBottomMargin, right: Length.sectionRightMargin)
-        collectionViewLayer.minimumInteritemSpacing = Length.cellHorizontalSpace
-        collectionViewLayer.minimumLineSpacing = Length.cellVerticalSpace
-        collectionViewLayer.headerReferenceSize = .init(width: Length.headerWidth, height: Length.headerHeight)
-        self.templateCollectionView?.setCollectionViewLayout(collectionViewLayer, animated: false)
-    }
-    
-    // 컬렉션 뷰 초기화
-    private func setCollectionView() {
-        templateCollectionView = PaperTemplateCollectionView(frame: .zero, collectionViewLayout: .init())
-        setCollectionViewLayout()
-        
-        guard let collectionView = templateCollectionView else {return}
-        collectionView.backgroundColor = .systemBackground
-        collectionView.alwaysBounceVertical = true
-        collectionView.register(PaperTemplateCollectionCell.self, forCellWithReuseIdentifier: PaperTemplateCollectionCell.identifier)
-        collectionView.register(PaperTemplateCollectionHeader.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: PaperTemplateCollectionHeader.identifier)
-        collectionView.dataSource = self
-        collectionView.delegate = self
-        collectionView.isHidden = true
-        
-        view.addSubview(collectionView)
-        collectionView.snp.makeConstraints({ make in
-            make.leading.trailing.bottom.equalToSuperview()
-            make.top.equalTo(view.safeAreaLayoutGuide)
-        })
+        collectionViewLayer.sectionInset = UIEdgeInsets(top: PaperTemplateSelectLength.sectionTopMargin, left: PaperTemplateSelectLength.sectionLeftMargin, bottom: PaperTemplateSelectLength.sectionBottomMargin, right: PaperTemplateSelectLength.sectionRightMargin)
+        collectionViewLayer.minimumInteritemSpacing = PaperTemplateSelectLength.cellHorizontalSpace
+        collectionViewLayer.minimumLineSpacing = PaperTemplateSelectLength.cellVerticalSpace
+        collectionViewLayer.headerReferenceSize = .init(width: PaperTemplateSelectLength.headerWidth, height: PaperTemplateSelectLength.headerHeight)
+        return collectionViewLayer
     }
 }
 
@@ -179,19 +155,16 @@ class PaperTemplateSelectViewController: UIViewController {
 extension PaperTemplateSelectViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
     // 셀 크기
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return CGSize(width: Length.cellWidth, height: Length.cellHeight)
+        return CGSize(width: PaperTemplateSelectLength.cellWidth, height: PaperTemplateSelectLength.cellHeight)
     }
-    
     // 섹션별 셀 개수
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return isRecentExist && section == 0 ? 1 : viewModel.getTemplates().count
     }
-    
     // 섹션의 개수
     func numberOfSections(in collectionView: UICollectionView) -> Int {
         return isRecentExist ? 2 : 1
     }
-    
     // 특정 위치의 셀
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PaperTemplateCollectionCell.identifier, for: indexPath) as? PaperTemplateCollectionCell else {return UICollectionViewCell()}
@@ -204,7 +177,6 @@ extension PaperTemplateSelectViewController: UICollectionViewDelegate, UICollect
         
         return cell
     }
-    
     // 특정 위치의 헤더
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         if kind == UICollectionView.elementKindSectionHeader {
@@ -219,7 +191,6 @@ extension PaperTemplateSelectViewController: UICollectionViewDelegate, UICollect
             return UICollectionReusableView()
         }
     }
-    
     // 특정 셀 눌렀을 떄의 동작
     func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
         // 템플릿을 터치하는 순간 최근 템플릿으로 설정하기 위해 input에 값 설정하기
@@ -238,86 +209,23 @@ extension PaperTemplateSelectViewController: UICollectionViewDelegate, UICollect
     }
 }
 
-// 최근 사용한 템플릿과 원래 템플릿들을 모두 보여주는 컬렉션 뷰
-private class PaperTemplateCollectionView: UICollectionView {}
-
-// 컬렉션 뷰에서 섹션의 제목을 보여주는 뷰
-private class PaperTemplateCollectionHeader: UICollectionReusableView {
-    static let identifier = "CollectionHeader"
-    private let title = UILabel()
-    
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        configure()
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
+// 스냅킷 설정
+extension PaperTemplateSelectViewController {
     private func configure() {
-        addSubview(title)
-        
-        title.font = .preferredFont(forTextStyle: .title2)
-        title.snp.makeConstraints({ make in
-            make.top.equalToSuperview()
-            make.leading.equalToSuperview().offset(Length.headerLeftMargin)
+        view.addSubview(templateCollectionView)
+        view.addSubview(spinner)
+    }
+    
+    private func setConstraints() {
+        templateCollectionView.snp.makeConstraints({ make in
+            make.leading.trailing.bottom.equalToSuperview()
+            make.top.equalTo(view.safeAreaLayoutGuide)
         })
-    }
-    
-    func setHeader(text: String) {
-        title.text = text
-    }
-}
-
-// 컬렉션 뷰에 들어가는 셀들을 보여주는 뷰
-private class PaperTemplateCollectionCell: UICollectionViewCell {
-    static let identifier = "CollectionCell"
-    private let cell = UIStackView()
-    private let title = UILabel()
-    private let imageView = UIImageView()
-    
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        configure()
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    private func configure() {
-        addSubview(cell)
-        cell.addArrangedSubview(imageView)
-        cell.addArrangedSubview(title)
-        
-        cell.spacing = Length.templateTitleTopMargin
-        cell.axis = .vertical
-        cell.snp.makeConstraints({ make in
+        spinner.snp.makeConstraints({ make in
             make.edges.equalToSuperview()
         })
-        
-        imageView.layer.masksToBounds = true
-        imageView.layer.cornerRadius = Length.templateThumbnailCornerRadius
-        imageView.contentMode = .scaleAspectFill
-        imageView.snp.makeConstraints({ make in
-            make.top.equalToSuperview()
-            make.leading.equalToSuperview()
-            make.width.equalTo(Length.templateThumbnailWidth)
-            make.height.equalTo(Length.templateThumbnailHeight)
-        })
-        
-        title.font = .preferredFont(forTextStyle: .body)
-        title.textColor = UIColor(rgb: 0x808080)
-        title.textAlignment = .center
-        title.snp.makeConstraints({ make in
-            make.centerX.equalTo(imageView)
-            make.width.equalToSuperview()
-        })
-    }
-    
-    func setCell(template: TemplateModel) {
-        imageView.image = template.thumbnail
-        title.text = template.templateString
     }
 }
+
+// 최근 사용한 템플릿과 원래 템플릿들을 모두 보여주는 컬렉션 뷰
+private class PaperTemplateCollectionView: UICollectionView {}

--- a/RollingPaper/RollingPaper/ViewModels/Core/PaperStorage/PaperStorageViewModel.swift
+++ b/RollingPaper/RollingPaper/ViewModels/Core/PaperStorage/PaperStorageViewModel.swift
@@ -26,8 +26,8 @@ class PaperStorageViewModel {
     var closedPaperIds = Set<String>()
     var thumbnails = [String: UIImage?]()
     
-    private let timerViewModel = TimerViewModel()
-    private let timerInput: PassthroughSubject<TimerViewModel.Input, Never> = .init()
+    private let timeFlowManager = TimeFlowManager()
+    private let timerInput: PassthroughSubject<TimeFlowManager.Input, Never> = .init()
     private let output: PassthroughSubject<Output, Never> = .init()
     private var cancellables = Set<AnyCancellable>()
     private let localDatabaseManager: DatabaseManager
@@ -77,7 +77,7 @@ class PaperStorageViewModel {
     
     // 타이머 연동시키기
     private func bindTimer() {
-        let timerOutput = timerViewModel.transform(input: timerInput.eraseToAnyPublisher())
+        let timerOutput = timeFlowManager.transform(input: timerInput.eraseToAnyPublisher())
         timerOutput
             .receive(on: DispatchQueue.main)
             .sink(receiveValue: { [weak self] event in

--- a/RollingPaper/RollingPaper/ViewModels/Core/PaperStorage/PaperStorageViewModel.swift
+++ b/RollingPaper/RollingPaper/ViewModels/Core/PaperStorage/PaperStorageViewModel.swift
@@ -190,6 +190,10 @@ class PaperStorageViewModel {
                 }
             }
         }
+        
+        if papersFromLocal.isEmpty {
+            output.send(outputValue)
+        }
     }
     
     // url을 통해 서버에 저장되어있는 썸네일 다운받아오기
@@ -244,6 +248,10 @@ class PaperStorageViewModel {
                     self.output.send(outputValue)
                 }
             }
+        }
+        
+        if papersFromServer.isEmpty {
+            output.send(outputValue)
         }
     }
     

--- a/RollingPaper/RollingPaper/ViewModels/Core/PaperStorage/PaperStorageViewModel.swift
+++ b/RollingPaper/RollingPaper/ViewModels/Core/PaperStorage/PaperStorageViewModel.swift
@@ -5,10 +5,29 @@
 //  Created by 김동락 on 2022/10/12.
 //
 
-import UIKit
 import Combine
+import UIKit
 
 class PaperStorageViewModel {
+    private let timeFlowManager = TimeFlowManager()
+    private let timerInput: PassthroughSubject<TimeFlowManager.Input, Never> = .init()
+    private let output: PassthroughSubject<Output, Never> = .init()
+    private let localDatabaseManager: DatabaseManager
+    private let serverDatabaseManager: DatabaseManager
+    private var cancellables = Set<AnyCancellable>()
+    private var papersFromLocal = [PaperPreviewModel]()
+    private var papersFromServer = [PaperPreviewModel]()
+    private var papers = [PaperPreviewModel]()
+    
+    var currentTime: Date = Date()
+    var serverPaperIds = Set<String>()
+    var localPaperIds = Set<String>()
+    var openedPaperIds = Set<String>()
+    var closedPaperIds = Set<String>()
+    var thumbnails = [String: UIImage?]()
+    var openedPapers = [PaperPreviewModel]()
+    var closedPapers = [PaperPreviewModel]()
+    
     enum Input {
         case viewDidAppear
         case viewDidDisappear
@@ -19,60 +38,12 @@ class PaperStorageViewModel {
         case papersAreUpdatedInDatabase
         case papersAreUpdatedByTimer
     }
-    var currentTime: Date = Date()
-    var serverPaperIds = Set<String>()
-    var localPaperIds = Set<String>()
-    var openedPaperIds = Set<String>()
-    var closedPaperIds = Set<String>()
-    var thumbnails = [String: UIImage?]()
-    
-    private let timeFlowManager = TimeFlowManager()
-    private let timerInput: PassthroughSubject<TimeFlowManager.Input, Never> = .init()
-    private let output: PassthroughSubject<Output, Never> = .init()
-    private var cancellables = Set<AnyCancellable>()
-    private let localDatabaseManager: DatabaseManager
-    private let serverDatabaseManager: DatabaseManager
-    private var papersFromLocal = [PaperPreviewModel]()
-    private var papersFromServer = [PaperPreviewModel]()
-    private var papers = [PaperPreviewModel]()
-    var openedPapers = [PaperPreviewModel]()
-    var closedPapers = [PaperPreviewModel]()
     
     init(localDatabaseManager: DatabaseManager = LocalDatabaseFileManager.shared, serverDatabaseManager: DatabaseManager = FirestoreManager.shared) {
         self.localDatabaseManager = localDatabaseManager
         self.serverDatabaseManager = serverDatabaseManager
         bindTimer()
         bindDatabaseManager()
-    }
-    
-    // view controller에서 시그널을 받으면 그에 따라 어떤 행동을 할지 정함
-    func transform(input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
-        input
-            .receive(on: DispatchQueue.global(qos: .background))
-            .sink(receiveValue: { [weak self] event in
-                guard let self = self else {return}
-                switch event {
-                // 뷰가 나타났다는 시그널이 오면 타이머 bind 시키고 썸네일 새로 다운받기
-                case .viewDidAppear:
-                    self.timerInput.send(.viewDidAppear)
-                    self.updateCurrentTime()
-                    self.classifyPapers()
-                    self.downloadLocalThumbnails(outputValue: .initPapers)
-                    self.downloadServerThumbnails(outputValue: .initPapers)
-                // 뷰가 사라졌다는 시그널이 오면 타이머한테 알려줘서 타이머 해제시키기
-                case .viewDidDisappear:
-                    self.timerInput.send(.viewDidDisappear)
-                // 특정 페이퍼가 선택되면 로컬/서버 인지 구분하고 fetchpaper 실행
-                case .paperSelected(let paperId):
-                    if self.serverPaperIds.contains(paperId) {
-                        self.serverDatabaseManager.fetchPaper(paperId: paperId)
-                    } else {
-                        self.localDatabaseManager.fetchPaper(paperId: paperId)
-                    }
-                }
-            })
-            .store(in: &cancellables)
-        return output.eraseToAnyPublisher()
     }
     
     // 타이머 연동시키기
@@ -274,5 +245,35 @@ class PaperStorageViewModel {
                 }
             }
         }
+    }
+    
+    // view controller에서 시그널을 받으면 그에 따라 어떤 행동을 할지 정함
+    func transform(input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
+        input
+            .receive(on: DispatchQueue.global(qos: .background))
+            .sink(receiveValue: { [weak self] event in
+                guard let self = self else {return}
+                switch event {
+                // 뷰가 나타났다는 시그널이 오면 타이머 bind 시키고 썸네일 새로 다운받기
+                case .viewDidAppear:
+                    self.timerInput.send(.viewDidAppear)
+                    self.updateCurrentTime()
+                    self.classifyPapers()
+                    self.downloadLocalThumbnails(outputValue: .initPapers)
+                    self.downloadServerThumbnails(outputValue: .initPapers)
+                // 뷰가 사라졌다는 시그널이 오면 타이머한테 알려줘서 타이머 해제시키기
+                case .viewDidDisappear:
+                    self.timerInput.send(.viewDidDisappear)
+                // 특정 페이퍼가 선택되면 로컬/서버 인지 구분하고 fetchpaper 실행
+                case .paperSelected(let paperId):
+                    if self.serverPaperIds.contains(paperId) {
+                        self.serverDatabaseManager.fetchPaper(paperId: paperId)
+                    } else {
+                        self.localDatabaseManager.fetchPaper(paperId: paperId)
+                    }
+                }
+            })
+            .store(in: &cancellables)
+        return output.eraseToAnyPublisher()
     }
 }

--- a/RollingPaper/RollingPaper/ViewModels/Core/PaperTemplate/PaperSettingViewModel.swift
+++ b/RollingPaper/RollingPaper/ViewModels/Core/PaperTemplate/PaperSettingViewModel.swift
@@ -5,28 +5,22 @@
 //  Created by 김동락 on 2022/10/07.
 //
 
-import UIKit
 import Combine
+import UIKit
 
 class PaperSettingViewModel {
+    static let defaultTime = "1시간 00분"
+    
+    private let databaseManager: DatabaseManager
+    private let output: PassthroughSubject<Output, Never> = .init()
+    private var cancellables = Set<AnyCancellable>()
+    private let authManager: AuthManager = FirebaseAuthManager.shared
     private var paperTitle: String = ""
     private var paperDurationHour: Int = 2
     private var template: TemplateEnum
     private var currentUser: UserModel?
     private var selectedTime: String = defaultTime
-    
-    private let databaseManager: DatabaseManager
-    private let output: PassthroughSubject<Output, Never> = .init()
-    private let authManager: AuthManager = FirebaseAuthManager.shared
-    static let defaultTime = "1시간 00분"
-    
-    init(databaseManager: DatabaseManager = LocalDatabaseFileManager.shared, template: TemplateEnum) {
-        self.databaseManager = databaseManager
-        self.template = template
-        //처음에 로그인 한 상태로 생성하기 버튼을 눌렀을 떄 페이퍼의 creator를 넣어주기 위함
-        setCurrentPaperCreator()
-    }
-    
+        
     enum Input {
         case setPaperTitle(title: String)
         case endSettingPaper
@@ -37,33 +31,17 @@ class PaperSettingViewModel {
         case timePickerChange(time: String)
     }
     
-    private var cancellables = Set<AnyCancellable>()
-    
-    // 어떤 행동이 Input으로 들어오면 그것에 맞는 행동을 Output에 저장한 뒤 반환해주기
-    func transform(input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
-        input
-            .sink(receiveValue: { [weak self] event in
-                guard let self = self else {return}
-                switch event {
-                case .setPaperTitle(let title):
-                    self.setPaperTitle(title: title)
-                case .endSettingPaper:
-                    self.createPaper()
-                case .timePickerChange(let time):
-                    self.selectedTime = time
-                    self.output.send(.timePickerChange(time: time))
-                }
-            })
-            .store(in: &cancellables)
-        return output.eraseToAnyPublisher()
+    init(databaseManager: DatabaseManager = LocalDatabaseFileManager.shared, template: TemplateEnum) {
+        self.databaseManager = databaseManager
+        self.template = template
+        //처음에 로그인 한 상태로 생성하기 버튼을 눌렀을 떄 페이퍼의 creator를 넣어주기 위함
+        setCurrentPaperCreator()
     }
     
     // 형식 계산해서 종료 시간 반환해주기
     private func getPaperEndTime(duration: String) -> Date {
-        // 또는 아래와 같이 구할 수도 있다
         let hour = Int(duration.substring(start: 0, end: 1)) ?? 0
         let minute = Int(duration.substring(start: 4, end: 6)) ?? 0
-
         let totalMinute = hour*60+minute
         return Calendar.current.date(byAdding: .minute, value: totalMinute, to: Date()) ?? Date()
     }
@@ -72,7 +50,6 @@ class PaperSettingViewModel {
     private func setPaperTitle(title: String) {
         self.paperTitle = title
     }
-    
     
     // 페이퍼 만들기
     private func createPaper() {
@@ -91,5 +68,24 @@ class PaperSettingViewModel {
                 self?.currentUser = userProfile
             }
             .store(in: &cancellables)
+    }
+    
+    // 어떤 행동이 Input으로 들어오면 그것에 맞는 행동을 Output에 저장한 뒤 반환해주기
+    func transform(input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
+        input
+            .sink(receiveValue: { [weak self] event in
+                guard let self = self else {return}
+                switch event {
+                case .setPaperTitle(let title):
+                    self.setPaperTitle(title: title)
+                case .endSettingPaper:
+                    self.createPaper()
+                case .timePickerChange(let time):
+                    self.selectedTime = time
+                    self.output.send(.timePickerChange(time: time))
+                }
+            })
+            .store(in: &cancellables)
+        return output.eraseToAnyPublisher()
     }
 }

--- a/RollingPaper/RollingPaper/ViewModels/Core/PaperTemplate/PaperTemplateSelectViewModel.swift
+++ b/RollingPaper/RollingPaper/ViewModels/Core/PaperTemplate/PaperTemplateSelectViewModel.swift
@@ -5,23 +5,36 @@
 //  Created by 김동락 on 2022/10/05.
 //
 
-import UIKit
 import Combine
+import UIKit
 
-class PaperTemplateSelectViewModel {
-    
+final class PaperTemplateSelectViewModel {
+    private let output: PassthroughSubject<Output, Never> = .init()
+    private var cancellables = Set<AnyCancellable>()
+
     enum Input {
         case viewDidAppear
         case newTemplateTap(template: TemplateEnum)
     }
-    
     enum Output {
         case getRecentTemplateSuccess(template: TemplateEnum)
         case getRecentTemplateFail
     }
     
-    private let output: PassthroughSubject<Output, Never> = .init()
-    private var cancellables = Set<AnyCancellable>()
+    // 최근 선택한 템플릿이 뭔지 유저 디폴트에 저장
+    private func saveRecentTemplate(template: TemplateEnum) {
+        UserDefaults.standard.set(template.template.templateString, forKey: "recentTemplate")
+    }
+    
+    // 최근 템플릿이 존재하는지 확인하고 가져오기
+    private func getRecentTemplate() {
+        if let recentTemplateString = UserDefaults.standard.value(forKey: "recentTemplate") as? String,
+           let template = TemplateEnum(rawValue: recentTemplateString) {
+            output.send(.getRecentTemplateSuccess(template: template))
+        } else {
+            output.send(.getRecentTemplateFail)
+        }
+    }
     
     // 어떤 행동이 Input으로 들어오면 그것에 맞는 행동을 Output에 저장한 뒤 반환해주기
     func transform(input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
@@ -39,21 +52,6 @@ class PaperTemplateSelectViewModel {
             })
             .store(in: &cancellables)
         return output.eraseToAnyPublisher()
-    }
-
-    // 최근 선택한 템플릿이 뭔지 유저 디폴트에 저장
-    private func saveRecentTemplate(template: TemplateEnum) {
-        UserDefaults.standard.set(template.template.templateString, forKey: "recentTemplate")
-    }
-    
-    // 최근 템플릿이 존재하는지 확인하고 가져오기
-    private func getRecentTemplate() {
-        if let recentTemplateString = UserDefaults.standard.value(forKey: "recentTemplate") as? String,
-           let template = TemplateEnum(rawValue: recentTemplateString) {
-            output.send(.getRecentTemplateSuccess(template: template))
-        } else {
-            output.send(.getRecentTemplateFail)
-        }
     }
     
     // 만들어둔 모든 템플릿 가져오기


### PR DESCRIPTION
# Issue Number
🔒 Close #268
🔒 Close #252 

## New features
- 페이퍼 템플릿 뷰 -> 앱을 처음 켰을 때만 잠깐 로딩뷰가 나옵니다
- 페이퍼 보관함 뷰 -> 이 화면으로 이동할때마다 로딩뷰가 나옵니다
- 코드 리팩터링 -> 노션에 써져있는 컨벤션대로 바꾸기, 파일 분리, 주석 달기, 쓸데없는 코드 지우기

![Simulator Screen Recording - iPad (10th generation) - 2022-11-14 at 15 33 39](https://user-images.githubusercontent.com/72330884/201591371-46a80b7a-ae3c-4aed-a240-e8f6a1e7f42f.gif)


## Checklist
- [X] Is the branch you are merging on correct?
- [X] Do you comply with coding conventions?
- [X] Are there any changes not related to PR?
- [X] Has my code been self-reviewed?
