### PR TITLE
Feature/modify sidebar category cells/#278 #281

### DIFF
--- a/RollingPaper/RollingPaper/ViewControllers/Core/PaperTemplate/PaperSettingViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/PaperTemplate/PaperSettingViewController.swift
@@ -358,7 +358,7 @@ class PaperSettingViewController: UIViewController {
               NotificationCenter.default.post(
                   name: Notification.Name.viewChange,
                   object: nil,
-                  userInfo: [NotificationViewKey.view: "페이퍼 보관함"]
+                  userInfo: [NotificationViewKey.view: "보관함"]
               )
           }
       }

--- a/RollingPaper/RollingPaper/ViewControllers/Core/Sidebar/SidebarViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/Sidebar/SidebarViewController.swift
@@ -36,8 +36,9 @@ final class SidebarViewController: UIViewController {
     private let viewModel = SidebarViewModel()
     private var cancellables = Set<AnyCancellable>()
     private let sideBarCategories: [CategoryModel] = [
-        CategoryModel(name: "페이퍼 템플릿", icon: "doc.on.doc"),
-        CategoryModel(name: "페이퍼 보관함", icon: "folder"),
+        CategoryModel(name: "새 페이퍼", icon: "doc.on.doc"),
+        CategoryModel(name: "보관함", icon: "folder"),
+        CategoryModel(name: "선물 상자", icon: "giftcard"),
         CategoryModel(name: "설정", icon: "gearshape")
     ]
     

--- a/RollingPaper/RollingPaper/ViewControllers/Core/Sidebar/SidebarViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/Sidebar/SidebarViewController.swift
@@ -98,7 +98,7 @@ final class SidebarViewController: UIViewController {
     
     @objc private func changeSecondaryView(noitificaiton: Notification) {
         guard let object = noitificaiton.userInfo?[NotificationViewKey.view] as? String else { return }
-        if object == "페이퍼 보관함" {
+        if object == "보관함" {
             self.collectionView.selectItem(at: IndexPath(row: 1, section: 0), animated: false, scrollPosition: UICollectionView.ScrollPosition.centeredHorizontally)
         }
     }

--- a/RollingPaper/RollingPaper/ViewControllers/Core/Sidebar/SidebarViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/Sidebar/SidebarViewController.swift
@@ -189,8 +189,8 @@ final class SidebarViewController: UIViewController {
         userInfoStack.isLayoutMarginsRelativeArrangement = true
         userInfoStack.layoutMargins = Layout.userInfoStackInset
         userInfoStack.snp.makeConstraints { make in
-            make.leading.equalToSuperview().offset(Layout.userInfoStackLeadingSuperView)
-            make.trailing.equalToSuperview().offset(Layout.userInfoStackTrailingSuperView)
+            make.leading.equalTo(view.safeAreaLayoutGuide).offset(16)
+            make.trailing.equalTo(view.safeAreaLayoutGuide).inset(16)
             make.height.equalTo(userInfoStack.snp.width).dividedBy(3)
             make.top.equalTo(view.safeAreaLayoutGuide).offset(Layout.userInfoStackTopSafeArea)
         }

--- a/RollingPaper/RollingPaper/ViewControllers/Other/WrittenPaper/WrittenPaperViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Other/WrittenPaper/WrittenPaperViewController.swift
@@ -201,7 +201,7 @@ final class WrittenPaperViewController: UIViewController {
         NotificationCenter.default.post(
             name: Notification.Name.viewChange,
             object: nil,
-            userInfo: [NotificationViewKey.view: "페이퍼 보관함"]
+            userInfo: [NotificationViewKey.view: "보관함"]
         )
     }
     


### PR DESCRIPTION
# Issue Number
🔒 Close #278 
🔒 Close #281

## New features

- write here
- 사이드바에 선물 상자 셀을 추가했습니다.
- 사이드바 내부 카테고리들의 이름을 변경했습니다.
    - "페이퍼 템플릿" -> "새 페이퍼"
    - "페이퍼 보관함" -> "보관함"
- 바뀐 카테고리들의 이름에 따라 notificationCenter Logic도 변경했습니다.
    - "선물 상자" 뷰가 생기면 연결 부탁드립니다.
    - <img width="578" alt="Screenshot 2022-11-14 at 4 09 56 PM" src="https://user-images.githubusercontent.com/57012734/201596846-dcd1abd8-2308-445f-b9a0-48a0e4d1b524.png">
- Additional) UserinfoStack의 leading Anchor를  사이드바 CollectionView의 leading Anchor와 같게 만들었습니다.
    - 너무 단순한 수치 변경이라 브랜치를 파는 것이 오히려 더 Git flow를 난잡하게 만들 것이라고 판단하여 묶었습니다. 
    - #281 
- Additional) SplitViewController의 viewDidLoad() 내부 코드들을 함수로 묶었습니다.
- screenshot(optional)
![Simulator Screen Shot - iPad (10th generation) - 2022-11-14 at 17 30 49](https://user-images.githubusercontent.com/57012734/201612181-85be961e-a9f2-414d-8927-600ab5e8c13c.png)

## Checklist

- [x] Is the branch you are merging on correct?
- [x] Do you comply with coding conventions?
- [x] Are there any changes not related to PR?
- [x] Has my code been self-reviewed?
