### PR TITLE
Bug/complete button click white image bug/#285

### DIFF
--- a/RollingPaper/RollingPaper/ViewControllers/Other/Card/CardResultViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Other/Card/CardResultViewController.swift
@@ -76,7 +76,9 @@ final class CardResultViewController: UIViewController {
     }()
     
     lazy var titleBounceView: UILabel = {
-        let titleLabel = UILabel(frame: CGRect(x: (view.bounds.width*0.5)-117, y: 70, width: 234, height: 54))
+        let titleLabel = UILabel()
+      //  let titleLabel = UILabel(frame: CGRect(x: (view.bounds.width*0.5)-117, y: someImageView.bounds.height*0.5, width: 234, height: 54))
+        titleLabel.text = "이대로 게시할까요?"
         titleLabel.text = "이대로 게시할까요?"
         titleLabel.textAlignment = .center
         titleLabel.font = UIFont.systemFont(ofSize: 20, weight: .bold)
@@ -108,6 +110,7 @@ final class CardResultViewController: UIViewController {
         someImageViewConstraints()
         
         view.addSubview(titleBounceView)
+        titleBounceViewConstraints()
         animationBounce()
         
         view.addSubview(backwardButton)
@@ -146,12 +149,22 @@ final class CardResultViewController: UIViewController {
 }
 
 extension CardResultViewController {
+    
+    private func titleBounceViewConstraints() {
+        titleBounceView.snp.makeConstraints({ make in
+            make.width.equalTo(234)
+            make.height.equalTo(54)
+            make.centerX.equalTo(self.view)
+            make.centerY.equalTo(self.view)
+            make.bottom.equalTo(someImageView.snp.top).offset(-30)
+        })
+    }
     private func someImageShadowConstraints() {
         someImageShadow.snp.makeConstraints({ make in
             make.width.equalTo(self.view.bounds.width * 0.60)
             make.height.equalTo(self.view.bounds.height * 0.60)
             make.centerX.equalTo(self.view)
-            make.top.equalTo(self.view.snp.top).offset(150)
+            make.centerY.equalTo(self.view)
         })
     }
     
@@ -160,7 +173,7 @@ extension CardResultViewController {
             make.width.equalTo(self.view.bounds.width * 0.60)
             make.height.equalTo(self.view.bounds.height * 0.60)
             make.centerX.equalTo(self.view)
-            make.top.equalTo(self.view.snp.top).offset(150)
+            make.centerY.equalTo(self.view)
         })
     }
     

--- a/RollingPaper/RollingPaper/ViewControllers/Other/Card/CardRootViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Other/Card/CardRootViewController.swift
@@ -138,7 +138,9 @@ class CardRootViewController: UIViewController {
             present(alert, animated: true)
         } else {
             if let cardCreateViewVC = self.children[0] as? CardCreateViewController {
+                if completeClickCount == 0 {
                     cardCreateViewVC.resultImageSend()
+                }
                 print("CardPencilKit here!")
             } else {
                 print("Fail!")


### PR DESCRIPTION
# Issue Number
🔒 Close #285 

## New features

- '실기계 테스트 환경'
- CardCreate 화면에서 완료 버튼을 연타 
   -> Result화면에 하얀 배경이 넘어가는 버그 해결 
   -> CardRootViewController에서 completeClickCount: Int = 0 으로 선언
   -> func openResultView가 호출되면 completeClickCount: Int = 1으로 변경되고,
   -> 다시 CardRootViewController으로 돌아오면 completeClickCount: Int = 0 으로 초기화 
   -> 따라서 func openResultView 이 한번만 호출되므로 버그 해결.

## Review points

- write here

## Questions

- write here

## References

- write here 

## Checklist

- [ ] Is the branch you are merging on correct?
- [ ] Do you comply with coding conventions?
- [ ] Are there any changes not related to PR?
- [ ] Has my code been self-reviewed?
