### PR TITLE
Feature/add gift button and status checking logic/#290

### DIFF
--- a/RollingPaper/RollingPaper/Models/PaperModel.swift
+++ b/RollingPaper/RollingPaper/Models/PaperModel.swift
@@ -13,7 +13,7 @@ struct PaperModel: Codable {
     var creator: UserModel?
     var cards: [CardModel]
     let date: Date
-    let endTime: Date
+    var endTime: Date
     var title: String
     var linkUrl: URL?
     var templateString: String


### PR DESCRIPTION
# Issue Number
🔒 Close #290

## New features

- 종료된 페이퍼 우측 상단에 버튼 3개 지우고 선물하기 버튼 넣기

## Review points

- 타이머 마감버튼을 누르면 일어나는 변화가 
  - 네비바 오른쪽의 버튼 덩어리들 UI 변경
  - 카드 컬렉션 뷰의 카드 생성하기 버튼 삭제 및 인덱스 변경
  - 페이퍼가 종료된 페이퍼로 넘어감
  - 로컬/서버 manager에 paper 상태 update

- 이 뿐만 아니라  currentPaper의 endTime을 페이퍼 생성시간인 date로 바꿔 타이머에도 UI에 변경을 줘야 합니다. 
   그리고 바뀐 PaperModel의 적용도 필요합니다.

- 이를 적용하기 위해 변경된 timeLabel 을 적용해야 하고, 나머지 로직에 시간에 대한 변수를 적용해야 하므로 일단 네비바 오른쪽의 버튼 덩어리들 UI가 바뀌는 부분 먼저 머지하겠습니다. 

- 그 후 변경된 timeLabel이 적용된 dev 에서 새로 브랜치를 파서 '마감하기' 의 나머지 로직을 완성하겠습니다.

## Questions

- write here

## References

- write here 

## Checklist

- [ ] Is the branch you are merging on correct?
- [ ] Do you comply with coding conventions?
- [ ] Are there any changes not related to PR?
- [ ] Has my code been self-reviewed?
