### PR TITLE
Feature/sort by year/#305

### DIFF
--- a/RollingPaper/RollingPaper/ViewControllers/Core/GiftStorage/GiftStorageCollcectionHeader.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/GiftStorage/GiftStorageCollcectionHeader.swift
@@ -14,7 +14,8 @@ final class GiftStorageCollectionHeader: UICollectionReusableView {
     
     private lazy var title: UILabel = {
         let title = UILabel()
-        title.font = .preferredFont(forTextStyle: .title2)
+        title.font = .systemFont(ofSize: 48, weight: .black)
+        title.textColor = UIColor(rgb: 0xD9D9D9)
         return title
     }()
     

--- a/RollingPaper/RollingPaper/ViewControllers/Core/GiftStorage/GiftStorageLength.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/GiftStorage/GiftStorageLength.swift
@@ -10,9 +10,9 @@ import UIKit
 final class GiftStorageLength {
     static let paperThumbnailCornerRadius: CGFloat = 12
     static let headerWidth: CGFloat = 200 // 임시
-    static let headerHeight: CGFloat = 29
-    static let headerLeftMargin: CGFloat = 37
-    static let sectionTopMargin: CGFloat = 16
+    static let headerHeight: CGFloat = 57
+    static let headerLeftMargin: CGFloat = 45
+    static let sectionTopMargin: CGFloat = -11
     static let sectionBottomMargin: CGFloat = 48
     static let sectionRightMargin: CGFloat = 36
     static let sectionLeftMargin: CGFloat = 36

--- a/RollingPaper/RollingPaper/ViewControllers/Core/GiftStorage/GiftStorageViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/GiftStorage/GiftStorageViewController.swift
@@ -171,17 +171,17 @@ extension GiftStorageViewController: UICollectionViewDelegate, UICollectionViewD
     }
     // 섹션별 셀 개수
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return viewModel.papers.count
+        return viewModel.papersByYear[viewModel.years[section]]?.count ?? 0
     }
     // 섹션의 개수
     func numberOfSections(in collectionView: UICollectionView) -> Int {
-        return 1
+        return viewModel.years.count
     }
     // 특정 위치의 셀
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: GiftStorageCollectionCell.identifier, for: indexPath) as? GiftStorageCollectionCell else {return UICollectionViewCell()}
-
-        let paper = viewModel.papers[indexPath.item]
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: GiftStorageCollectionCell.identifier, for: indexPath) as? GiftStorageCollectionCell,
+              let paper = viewModel.papersByYear[viewModel.years[indexPath.section]]?[indexPath.item]
+        else {return UICollectionViewCell()}
         let thumbnail = viewModel.thumbnails[paper.paperId, default: paper.template.thumbnail]
         cell.setCell(paper: paper, thumbnail: thumbnail)
         
@@ -195,7 +195,7 @@ extension GiftStorageViewController: UICollectionViewDelegate, UICollectionViewD
                 withReuseIdentifier: GiftStorageCollectionHeader.identifier,
                 for: indexPath
             ) as? GiftStorageCollectionHeader else {return UICollectionReusableView()}
-            supplementaryView.setHeader(text: "aaa")
+            supplementaryView.setHeader(text: viewModel.years[indexPath.section])
             return supplementaryView
         } else {
             return UICollectionReusableView()
@@ -203,9 +203,11 @@ extension GiftStorageViewController: UICollectionViewDelegate, UICollectionViewD
     }
     // 특정 셀 눌렀을 떄의 동작
     func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
-        setSelectedPaper(paperId: viewModel.papers[indexPath.item].paperId )
-        viewIsChange = true
-        navigationController?.pushViewController(WrittenPaperViewController(), animated: true)
+        // TODO: WrittenPaperViewController 말고 선물 전용 뷰로 이동해야함
+//        guard let paper = viewModel.papersByYear[viewModel.years[indexPath.section]]?[indexPath.item] else {return false}
+//        setSelectedPaper(paperId: paper.paperId )
+//        viewIsChange = true
+//        navigationController?.pushViewController(WrittenPaperViewController(), animated: true)
         return true
     }
 }

--- a/RollingPaper/RollingPaper/ViewModels/Core/GiftStorage/GiftStorageViewModel.swift
+++ b/RollingPaper/RollingPaper/ViewModels/Core/GiftStorage/GiftStorageViewModel.swift
@@ -221,8 +221,6 @@ class GiftStorageViewModel {
                 papersByYearTemp[year]?.append(paper)
             }
         }
-        yearsTemp.append("2020")
-        yearsTemp.append("2021")
         yearsTemp = yearsTemp.sorted().reversed()
         
         papersByYear = papersByYearTemp

--- a/RollingPaper/RollingPaper/ViewModels/Core/GiftStorage/GiftStorageViewModel.swift
+++ b/RollingPaper/RollingPaper/ViewModels/Core/GiftStorage/GiftStorageViewModel.swift
@@ -208,9 +208,12 @@ class GiftStorageViewModel {
             }
         }
         
-        let papers = papersLocalOnly + papersFromServer
+        var papers = papersLocalOnly + papersFromServer
+        papers.sort(by: {return $1.date < $0.date})
+        
         var papersByYearTemp = [String: [PaperPreviewModel]]()
         var yearsTemp = [String]()
+        
         
         for paper in papers {
             let year = getYear(date: paper.date)

--- a/RollingPaper/RollingPaper/ViewModels/Core/PaperStorage/PaperStorageViewModel.swift
+++ b/RollingPaper/RollingPaper/ViewModels/Core/PaperStorage/PaperStorageViewModel.swift
@@ -122,7 +122,7 @@ class PaperStorageViewModel {
         }
         // 만든 시간 순서대로 정렬
         papers = papersLocalOnly + papersFromServer
-        papers.sort(by: {return $0.date < $1.date})
+        papers.sort(by: {return $1.date < $0.date})
         
         // 열린 페이퍼와 닫힌 페이퍼 구분
         var opened = [PaperPreviewModel]()


### PR DESCRIPTION
# Issue Number
🔒 Close #305 

## New features
- 선물 받은 페이퍼들을 연도별로 리스트에 저장되게함
- 헤더 (연도)를 피그마대로 꾸밈
- 컬렉션뷰에서 연도와 함께 해당 페이퍼들을 보여줌

## TODO
- 셀 터치는 아래 코드 사진에서 보듯이 일단 막아놨습니다.
- 선물 전용 뷰 (기존 WrittenPaper에서 +버튼이 없다든지) 로 이동해야합니다.

![Simulator Screen Shot - iPad mini (6th generation) - 2022-11-16 at 13 48 54](https://user-images.githubusercontent.com/72330884/202086468-6a8aa68b-b19b-44b3-9524-62792117ec22.png)

<img width="1119" alt="image" src="https://user-images.githubusercontent.com/72330884/202086770-8d28fa1f-7b1d-4234-bbaa-d64d7571bd6b.png">


## Review points

- write here

## Questions

- write here

## References

- write here 

## Checklist

- [ ] Is the branch you are merging on correct?
- [ ] Do you comply with coding conventions?
- [ ] Are there any changes not related to PR?
- [ ] Has my code been self-reviewed?
