### PR TITLE
Bug/fix the button crash in CardCreate/#314

### DIFF
--- a/RollingPaper/RollingPaper/ViewControllers/Other/Card/CardCreateViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Other/Card/CardCreateViewController.swift
@@ -306,6 +306,7 @@ class CardCreateViewController: UIViewController, UINavigationControllerDelegate
     }
     
     private func cameraOffButtonAppear() {
+        cameraOnButton.removeFromSuperview()
         view.addSubview(cameraOffButton)
         cameraOffButtonConstraints()
     }
@@ -316,6 +317,7 @@ class CardCreateViewController: UIViewController, UINavigationControllerDelegate
     }
     
     private func backgroundOffButtonAppear() {
+        backgroundOnButton.removeFromSuperview()
         view.addSubview(backgroundOffButton)
         backgroundOffButtonConstraints()
     }
@@ -331,6 +333,7 @@ class CardCreateViewController: UIViewController, UINavigationControllerDelegate
     }
     
     private func pencilButtonOff() {
+        pencilOnButton.removeFromSuperview()
         view.addSubview(pencilOffButton)
         pencilOffButtonConstraints()
     }
@@ -341,6 +344,7 @@ class CardCreateViewController: UIViewController, UINavigationControllerDelegate
     }
     
     private func stickerButtonOff() {
+        stickerOnButton.removeFromSuperview()
         view.addSubview(stickerOffButton)
         stickerOffButtonConstraints()
     }

--- a/RollingPaper/RollingPaper/ViewControllers/Other/Card/CardCreateViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Other/Card/CardCreateViewController.swift
@@ -31,15 +31,15 @@ class CardCreateViewController: UIViewController, UINavigationControllerDelegate
     private var imageSticker: UIImage!
     
     private let imageShadowView: UIView = {
-        let aView = UIView()
-        aView.layer.shadowOffset = CGSize(width: 3, height: 3)
-        aView.layer.shadowOpacity = 0.2
-        aView.layer.shadowRadius = 30.0
-        aView.backgroundColor = .systemBackground
-        aView.layer.cornerRadius = 60
-        aView.layer.shadowColor = UIColor.black.cgColor
-        aView.translatesAutoresizingMaskIntoConstraints = false
-        return aView
+        let shadowUIView = UIView()
+        shadowUIView.layer.shadowOffset = CGSize(width: 3, height: 3)
+        shadowUIView.layer.shadowOpacity = 0.2
+        shadowUIView.layer.shadowRadius = 30.0
+        shadowUIView.backgroundColor = .systemBackground
+        shadowUIView.layer.cornerRadius = 60
+        shadowUIView.layer.shadowColor = UIColor.black.cgColor
+        shadowUIView.translatesAutoresizingMaskIntoConstraints = false
+        return shadowUIView
     }()
     
     lazy var rootUIImageView: UIImageView = {
@@ -200,7 +200,6 @@ class CardCreateViewController: UIViewController, UINavigationControllerDelegate
         tapRecognizer.numberOfTapsRequired = 1
         someImageView.addGestureRecognizer(tapRecognizer)
         
-        
         view.addSubview(rootUIImageView)
         rootUIImageViewConstraints()
         
@@ -301,23 +300,25 @@ class CardCreateViewController: UIViewController, UINavigationControllerDelegate
     }
     
     private func cameraOnButtonAppear() {
+        cameraOnButton.isHidden = false
         view.addSubview(cameraOnButton)
         cameraOnButtonConstraints()
     }
     
     private func cameraOffButtonAppear() {
-        cameraOnButton.removeFromSuperview()
+        cameraOnButton.isHidden = true
         view.addSubview(cameraOffButton)
         cameraOffButtonConstraints()
     }
     
     private func backgroundOnButtonAppear() {
+        backgroundOnButton.isHidden = false
         view.addSubview(backgroundOnButton)
         backgroundOnButtonConstraints()
     }
     
     private func backgroundOffButtonAppear() {
-        backgroundOnButton.removeFromSuperview()
+        backgroundOnButton.isHidden = true
         view.addSubview(backgroundOffButton)
         backgroundOffButtonConstraints()
     }
@@ -328,23 +329,25 @@ class CardCreateViewController: UIViewController, UINavigationControllerDelegate
     }
     
     private func pencilButtonOn() {
+        pencilOnButton.isHidden = false
         view.addSubview(pencilOnButton)
         pencilOnButtonConstraints()
     }
     
     private func pencilButtonOff() {
-        pencilOnButton.removeFromSuperview()
+        pencilOnButton.isHidden = true
         view.addSubview(pencilOffButton)
         pencilOffButtonConstraints()
     }
     
     private func stickerButtonOn() {
+        stickerOnButton.isHidden = false
         view.addSubview(stickerOnButton)
         stickerOnButtonConstraints()
     }
     
     private func stickerButtonOff() {
-        stickerOnButton.removeFromSuperview()
+        stickerOnButton.isHidden = true
         view.addSubview(stickerOffButton)
         stickerOffButtonConstraints()
     }
@@ -360,13 +363,11 @@ class CardCreateViewController: UIViewController, UINavigationControllerDelegate
     }
     
     private func stickerCollectionViewDisappear() {
-        view.addSubview(imageShadowView)
         imageShadowView.isHidden = true
+        view.addSubview(imageShadowView)
         imageShadowViewConstraints()
         
-        view.addSubview(collectionView)
         collectionView.isHidden = true
-        collectionViewConstraints()
     }
     
     @objc func setPopOverView(_ sender: UIButton) {
@@ -380,6 +381,14 @@ class CardCreateViewController: UIViewController, UINavigationControllerDelegate
         popover?.sourceView = sender
         popover?.sourceRect = CGRect(x: 25, y: 0, width: 50, height: 50)
         present(controller, animated: true)
+    }
+    
+    private func disableEditSticker() {
+        if selectedSticker != nil {
+            selectedSticker!.enabledControl = false
+            selectedSticker!.enabledBorder = false
+            selectedSticker = nil
+        }
     }
     
     @objc func togglebutton(_ gesture: UITapGestureRecognizer) {
@@ -409,14 +418,6 @@ class CardCreateViewController: UIViewController, UINavigationControllerDelegate
     
     @objc func tapBackground(recognizer: UITapGestureRecognizer) {
         disableEditSticker()
-    }
-    
-    private func disableEditSticker() {
-        if selectedSticker != nil {
-            selectedSticker!.enabledControl = false
-            selectedSticker!.enabledBorder = false
-            selectedSticker = nil
-        }
     }
 }
 


### PR DESCRIPTION
# Issue Number
🔒 Close #314

## New features

- .removeFromSuperview()을 각 버튼을 off 시키는 효과를 담당하는 "버튼 색깔 grey" 구문의 첫번째에 넣어주었습니다.
- .removeFromSuperview()은 App이 크러시 날 확율이 있으므로, 자제해야 함.
- 따라서 isHidden으로 컨트롤 하는 방향으로 추가 개발하였습니다.
- 이제 버튼을 눌럿다가 떼도, 버튼이 이상해 지지 않음, 
  -> grey버튼을 불러 올때, black 버튼을 뷰에서 제거 했기 때문입니다.

- screenshot(optional)
[개발 전]
<img width="132" alt="스크린샷 2022-11-16 오후 7 11 12" src="https://user-images.githubusercontent.com/40324511/202152463-ebe0a457-ca56-42f4-8bce-3831ef4bd99e.png">

[개발 후]
<img width="113" alt="스크린샷 2022-11-16 오후 7 12 12" src="https://user-images.githubusercontent.com/40324511/202152692-0232663e-808c-46fd-823d-1c9f3a2de553.png">



## Review points

- write here

## Questions

- write here

## References

- write here 

## Checklist

- [x] Is the branch you are merging on correct?
- [x] Do you comply with coding conventions?
- [x] Are there any changes not related to PR?
- [x] Has my code been self-reviewed?
