### PR TITLE
Feature/after signup events fixed/#330

### DIFF
--- a/RollingPaper/RollingPaper/Extensions/Notification.Name+Extension.swift
+++ b/RollingPaper/RollingPaper/Extensions/Notification.Name+Extension.swift
@@ -12,6 +12,7 @@ extension Notification.Name {
     static let viewChangeFromSidebar = Notification.Name("ViewChangeFromSidebar")
     static let deeplink = Notification.Name("deeplink")
     static let viewInit = Notification.Name("viewInit")
+    static let signUpDidSucceed = Notification.Name("signUpDidSucceed")
 }
 
 enum NotificationViewKey {

--- a/RollingPaper/RollingPaper/Managers/FirebaseAuthManager.swift
+++ b/RollingPaper/RollingPaper/Managers/FirebaseAuthManager.swift
@@ -318,12 +318,7 @@ extension FirebaseAuthManager: ASAuthorizationControllerDelegate, ASAuthorizatio
             return
         }
         
-        let firstName = appleIDCredential.fullName?.givenName ?? ""
-        let lastName = appleIDCredential.fullName?.familyName ?? ""
-        var name = firstName + lastName
-        if name.isEmpty {
-            name = "Default Name"
-        }
+        let name = "YOLO"
         
         let credential = OAuthProvider.credential(withProviderID: "apple.com", idToken: idTokenString, rawNonce: nonce)
         auth.signIn(with: credential) { [weak self] _, error in

--- a/RollingPaper/RollingPaper/ViewControllers/Core/Setting/SignInViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/Setting/SignInViewController.swift
@@ -136,6 +136,18 @@ final class SignInViewController: UIViewController {
     private var cancellables = Set<AnyCancellable>()
     private let input: PassthroughSubject<SignInViewModel.Input, Never> = .init()
     private var currentFocusedTextfieldY: CGFloat = .zero
+    private var observer: NSObjectProtocol?
+
+        init(email: String = "", password: String = "") {
+            emailTextField.text = email
+            passwordTextField.text = password
+            passwordTextField.isSecureTextEntry = true
+            super.init(nibName: nil, bundle: nil)
+        }
+
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -147,6 +159,31 @@ final class SignInViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         layoutIfModalView()
+    }
+    
+    deinit {
+        removeObserver()
+    }
+    
+    private func setObserver() {
+        observer = NotificationCenter.default.addObserver(forName: .signUpDidSucceed, object: nil, queue: .main, using: { [weak self] notification in
+            guard
+                let self = self,
+                let email = notification.userInfo?["email"] as? String,
+                let password = notification.userInfo?["password"] as? String else { return }
+            self.setTextFieldUI(textFieldFocused: .normal)
+            self.emailTextField.text = email
+            self.passwordTextField.text = password
+            self.emailTextField.sendActions(for: .editingDidEnd)
+            self.passwordTextField.sendActions(for: .editingDidEnd)
+        })
+    }
+    
+    private func removeObserver() {
+        if let observer = observer {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        observer = nil
     }
     
     private func bind() {

--- a/RollingPaper/RollingPaper/ViewControllers/Core/Setting/SignUpViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/Setting/SignUpViewController.swift
@@ -218,15 +218,25 @@ final class SignUpViewController: UIViewController {
     
     private func navigateToSignIn() {
         if let modalPresentingVC = presentingViewController as? SplitViewController {
-            modalPresentingVC.dismiss(animated: true) {
-                let signInVC = SignInViewController()
+            modalPresentingVC.dismiss(animated: true) { [weak self] in
+                guard
+                    let email = self?.viewModel.email.value,
+                    let password = self?.viewModel.password.value else { return }
+                let signInVC = SignInViewController(email: email, password: password)
                 let navVC = UINavigationController(rootViewController: signInVC)
                 navVC.modalPresentationStyle = .pageSheet
                 modalPresentingVC.present(navVC, animated: true)
             }
         } else {
+            postUserInfo()
             self.navigationController?.popViewController(animated: true)
         }
+    }
+    
+    private func postUserInfo() {
+        let email = viewModel.email.value
+        let password = viewModel.password.value
+        NotificationCenter.default.post(name: .signUpDidSucceed, object: nil, userInfo: ["email": email, "password": password])
     }
     
     private func handleError(error: AuthManagerEnum) {


### PR DESCRIPTION
# Issue Number
🔒 Close #330

## New features

* 1-1. 애플 로그인 이후 파이어스토어 데이터베이스에 저장되는 디폴트 이름을 YOLO로 명명합니다.
* 1-2. 애플 로그인을 할 때에는 기존 이메일 회원가입과 달리 이름 중복 검사를 하지 않습니다.

* 2-1. 설정 카테고리 내에서의 회원가입 → 로그인 pop 화면 전환 UX를 변경합니다.
* 2-2. 회원가입이 성공했다면, 네비게이션 스택에서 팝한 뒤 보이는 로그인 화면에 회원가입에서 사용한 이메일 / 비밀번호가 적혀 있습니다.
→ 생각할 거리: 네비게이션 부모 뷰(로그인 뷰)에 자식 뷰(회원가입 뷰)가 접근할 수 있는 방법에는 컴바인, 델리게이트 등 여러 가지 방법이 있겠지만, 연결의 용이성을 위해 노티피케이션 센터에 회원 정보를 딕셔너리로 넘겨주는 함수를 구현했습니다.
→ 네비게이션 상태에 남아 있는 상황에서만 옵저버를 달기 위해 `viewDidLoad`에서 해당 옵저버를 add, `deinit`에서 해당 옵저버를 remove해줍니다. 메모리 단에 남아 있을 때에만 (즉 ARC를 위해) 포스트를 들을 필요가 있기 때문입니다.

![Simulator Screen Recording - iPad (10th generation) - 2022-11-18 at 23 10 36](https://user-images.githubusercontent.com/95460398/202725779-1e1aa98d-2165-421d-8eb2-3f106587410c.gif)


* 3-1. 페이퍼 방 내에서의 회원가입 → 로그인 모달 present 화면 전환 UX를 변경합니다.
* 3-2. 회원가입이 성공했다면, 모달 뷰를 프레젠트한 뒤 보이는 로그인 화면에 회원가입에서 사용한 이메일 / 비밀번호가 적혀 있습니다.
→ 생각할 거리: 위의 네비게이션 상황과 달리 모달 뷰를 조정하는 것은 다소 까다롭습니다. 현재 메모리 스택에 올라가 있지 않은 상황일 수 있기 때문입니다. 로그인 → 회원 가입 → 로그인으로 가는 상황에서 로그인 뷰 컨트롤러는 계속해서 viewDidLoad, deinit을 반복합니다.
→ 회원 가입에서 해당 로그인 뷰를 present한 이후 completion에서 노티피케이션 함수를 호출하더라도 그 시점에서는 로그인 뷰 컨트롤러의 viewDidLoad 함수가 실행되지 않았기 때문에 옵저버 함수 실행이 불가능합니다. 
→ 차선책으로 init 단에서 별도로 이메일, 비밀번호 파라미터를 넘겨 처음부터 텍스트 필드를 채우는 방법을 사용했습니다. 기존 로그인 뷰 컨트롤러를 초기화하는 방법과 충돌하지 않도록 디폴트 값을 주었습니다.
![Simulator Screen Recording - iPad (10th generation) - 2022-11-18 at 23 11 29](https://user-images.githubusercontent.com/95460398/202725829-edfc6961-0be3-4e81-a284-bb16f7fee84e.gif)

* 기존 PR은 삭제하고 새로운 PR로 대체하겠습니다!

## Review points

- write here

## Questions

- write here

## References

- write here 

## Checklist

- [ ] Is the branch you are merging on correct?
- [ ] Do you comply with coding conventions?
- [ ] Are there any changes not related to PR?
- [ ] Has my code been self-reviewed?
