### PR TITLE
Feature/filter paper in localdb/#333

### DIFF
--- a/RollingPaper/RollingPaper/Managers/FirestoreManager.swift
+++ b/RollingPaper/RollingPaper/Managers/FirestoreManager.swift
@@ -34,10 +34,14 @@ final class FirestoreManager: DatabaseManager {
     
     /// 현재 로그인된 유저 프로필 데이터 퍼블리셔 구독: (1). 유저 프로필이 변경될 때 감지 가능 (2). 로드 시 자동으로 현재 로그인된 유저가 작성한 페이퍼 프리뷰 배열을 로드
     private func bind() {
-        if let currentUserEmail = UserDefaults.standard.value(forKey: "currentUserEmail") as? String {
-            self.currentUserEmail = currentUserEmail
-            self.loadPaperPreviews()
-        }
+        FirebaseAuthManager.shared.userProfileSubject
+            .sink { [weak self] userModel in
+                self?.papersSubject.send([])
+                guard let userModel = userModel else { return }
+                self?.currentUserEmail = userModel.email
+                self?.loadPaperPreviews()
+            }
+            .store(in: &cancellables)
     }
     
     /// (1). 페이퍼 아이디를 통해 파이어베이스 내 저장된 페이퍼 탐색 및 페이퍼 퍼블리셔에 로드 (2). 페이퍼 아이디에 대한 페이퍼 데이터가 존재하지 않을 때 유저의 페이퍼 프리뷰 배열 업데이트

--- a/RollingPaper/RollingPaper/Managers/LocalDatabaseFileManager.swift
+++ b/RollingPaper/RollingPaper/Managers/LocalDatabaseFileManager.swift
@@ -92,7 +92,9 @@ final class LocalDatabaseFileManager: DatabaseManager {
     private func bind() {
         FirebaseAuthManager.shared.userProfileSubject
             .sink { [weak self] userModel in
+                self?.papersSubject.send([])
                 self?.loadPaperPreviews(userModel: userModel)
+                print("aaa LocalDatabaseFileManager bind call")
             }
             .store(in: &cancellables)
     }


### PR DESCRIPTION
# Issue Number
🔒 Close #333 

## New features
- 게스트 상태: 게스트가 만든 페이퍼만 보입니다.
- 로그인 상태: 게스트가 만든 페이퍼 + 유저 이메일이 같은 페이퍼 + 카드 작성한 페이퍼만 보입니다
- 로그인 / 로그아웃 이후 바인딩을 통해 자동으로 패치합니다

![Simulator Screen Recording - iPad Pro (12 9-inch) (6th generation) - 2022-11-21 at 12 02 14](https://user-images.githubusercontent.com/95460398/202954567-dbbec09c-0274-4c8f-a74d-8724b594e237.gif)


## Review points

- write here

## Questions

- write here

## References

- write here 

## Checklist

- [ ] Is the branch you are merging on correct?
- [ ] Do you comply with coding conventions?
- [ ] Are there any changes not related to PR?
- [ ] Has my code been self-reviewed?
