### PR TITLE
Feature/make view for empty content/#341

### DIFF
--- a/RollingPaper/RollingPaper/ViewControllers/Core/GiftStorage/GiftStorageViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/GiftStorage/GiftStorageViewController.swift
@@ -18,6 +18,17 @@ final class GiftStorageViewController: UIViewController {
     private var splitViewIsOpened: Bool = true
     private var viewIsChange: Bool = false
     
+    // 빈 화면일 때 보여주는 뷰
+    private lazy var emptyView: UILabel = {
+        let emptyView = UILabel()
+        emptyView.font = .systemFont(ofSize: 24)
+        emptyView.textColor = UIColor(rgb: 0xADADAD)
+        emptyView.text = "선물함이 비어있어요"
+        emptyView.textAlignment = .center
+        emptyView.isHidden = true
+        return emptyView
+    }()
+    
     // 데이터 로딩시 보여줄 스피너
     private lazy var spinner: UIActivityIndicatorView = {
         let spinner = UIActivityIndicatorView()
@@ -126,13 +137,18 @@ final class GiftStorageViewController: UIViewController {
     // 로딩뷰 띄워주거나 없애기
     private func updateLoadingView(isLoading: Bool) {
         if isLoading {
+            emptyView.isHidden = true
             paperCollectionView.isHidden = true
             spinner.isHidden = false
             spinner.startAnimating()
         } else {
             DispatchQueue.main.asyncAfter(deadline: .now()+0.2) { [weak self] in
                 guard let self = self else {return}
-                self.paperCollectionView.isHidden = false
+                if self.viewModel.papersByYear.isEmpty {
+                    self.emptyView.isHidden = false
+                } else {
+                    self.paperCollectionView.isHidden = false
+                }
                 self.spinner.isHidden = true
                 self.spinner.stopAnimating()
             }
@@ -216,11 +232,15 @@ extension GiftStorageViewController: UICollectionViewDelegate, UICollectionViewD
 extension GiftStorageViewController {
     private func configure() {
         view.addSubview(spinner)
+        view.addSubview(emptyView)
         view.addSubview(paperCollectionView)
     }
     
     private func setConstraints() {
         spinner.snp.makeConstraints({ make in
+            make.edges.equalToSuperview()
+        })
+        emptyView.snp.makeConstraints({ make in
             make.edges.equalToSuperview()
         })
         paperCollectionView.snp.makeConstraints({ make in

--- a/RollingPaper/RollingPaper/ViewControllers/Core/GiftStorage/GiftStorageViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/GiftStorage/GiftStorageViewController.swift
@@ -94,7 +94,7 @@ final class GiftStorageViewController: UIViewController {
                 case .initPapers:
                     self.updateLoadingView(isLoading: false)
                 case .papersAreUpdatedInDatabase:
-                    break
+                    self.updateMainView()
                 }
                 self.paperCollectionView.reloadData()
             })
@@ -152,6 +152,17 @@ final class GiftStorageViewController: UIViewController {
                 self.spinner.isHidden = true
                 self.spinner.stopAnimating()
             }
+        }
+    }
+    
+    // 빈 화면인지 컨텐츠가 있는지 체크하고 해당하는 뷰 띄워주기
+    private func updateMainView() {
+        if viewModel.papersByYear.isEmpty {
+            emptyView.isHidden = false
+            paperCollectionView.isHidden = true
+        } else {
+            emptyView.isHidden = true
+            paperCollectionView.isHidden = false
         }
     }
     

--- a/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageViewController.swift
@@ -27,6 +27,16 @@ final class PaperStorageViewController: UIViewController {
         case nothing, onlyOpened, onlyClosed, both
     }
     
+    // 빈 화면일 때 보여주는 뷰
+    private lazy var emptyView: UILabel = {
+        let emptyView = UILabel()
+        emptyView.font = .systemFont(ofSize: 24)
+        emptyView.textColor = UIColor(rgb: 0xADADAD)
+        emptyView.text = "보관함이 비어있어요"
+        emptyView.textAlignment = .center
+        emptyView.isHidden = true
+        return emptyView
+    }()
     // 데이터 로딩시 보여줄 스피너
     private lazy var spinner: UIActivityIndicatorView = {
         let spinner = UIActivityIndicatorView()
@@ -162,12 +172,17 @@ final class PaperStorageViewController: UIViewController {
     private func updateLoadingView(isLoading: Bool) {
         if isLoading {
             paperCollectionView.isHidden = true
+            emptyView.isHidden = true
             spinner.isHidden = false
             spinner.startAnimating()
         } else {
             DispatchQueue.main.asyncAfter(deadline: .now()+0.2) { [weak self] in
                 guard let self = self else {return}
-                self.paperCollectionView.isHidden = false
+                if self.dataState == .nothing {
+                    self.emptyView.isHidden = false
+                } else {
+                    self.paperCollectionView.isHidden = false
+                }
                 self.spinner.isHidden = true
                 self.spinner.stopAnimating()
             }
@@ -380,11 +395,15 @@ extension PaperStorageViewController: UICollectionViewDelegate, UICollectionView
 extension PaperStorageViewController {
     private func configure() {
         view.addSubview(spinner)
+        view.addSubview(emptyView)
         view.addSubview(paperCollectionView)
     }
     
     private func setConstraints() {
         spinner.snp.makeConstraints({ make in
+            make.edges.equalToSuperview()
+        })
+        emptyView.snp.makeConstraints({ make in
             make.edges.equalToSuperview()
         })
         paperCollectionView.snp.makeConstraints({ make in

--- a/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageViewController.swift
@@ -99,14 +99,17 @@ final class PaperStorageViewController: UIViewController {
             .receive(on: DispatchQueue.main)
             .sink(receiveValue: { [weak self] event in
                 guard let self = self else {return}
+                self.setDataState()
+                
                 switch event {
                     // 변화가 있으면 UI 업데이트 하기
                 case .initPapers:
                     self.updateLoadingView(isLoading: false)
-                case .papersAreUpdatedByTimer, .papersAreUpdatedInDatabase:
+                case .papersAreUpdatedInDatabase:
+                    self.updateMainView()
+                case .papersAreUpdatedByTimer:
                     break
                 }
-                self.setDataState()
                 
                 if self.isContextChosen == false {
                     self.paperCollectionView.reloadData()
@@ -186,6 +189,17 @@ final class PaperStorageViewController: UIViewController {
                 self.spinner.isHidden = true
                 self.spinner.stopAnimating()
             }
+        }
+    }
+    
+    // 빈 화면인지 컨텐츠가 있는지 체크하고 해당하는 뷰 띄워주기
+    private func updateMainView() {
+        if dataState == .nothing {
+            emptyView.isHidden = false
+            paperCollectionView.isHidden = true
+        } else {
+            emptyView.isHidden = true
+            paperCollectionView.isHidden = false
         }
     }
     

--- a/RollingPaper/RollingPaper/ViewModels/Core/PaperStorage/PaperStorageViewModel.swift
+++ b/RollingPaper/RollingPaper/ViewModels/Core/PaperStorage/PaperStorageViewModel.swift
@@ -82,6 +82,7 @@ class PaperStorageViewModel {
                 for paper in self.papersFromLocal {
                     self.localPaperIds.insert(paper.paperId)
                 }
+                self.classifyPapers()
                 self.downloadLocalThumbnails(outputValue: .papersAreUpdatedInDatabase)
             })
             .store(in: &cancellables)
@@ -96,6 +97,7 @@ class PaperStorageViewModel {
                 for paper in self.papersFromServer {
                     self.serverPaperIds.insert(paper.paperId)
                 }
+                self.classifyPapers()
                 self.downloadServerThumbnails(outputValue: .papersAreUpdatedInDatabase)
             })
             .store(in: &cancellables)


### PR DESCRIPTION
# Issue Number
🔒 Close #341 

## New features
- 페이퍼 보관함이 빈 화면일 때 비어있다는 문구를 표시해줍니다.
- 선물함이 빈 화면일 때 비어있다는 문구를 표시해줍니다.

![Simulator Screen Shot - iPad (10th generation) - 2022-11-23 at 15 31 17](https://user-images.githubusercontent.com/72330884/203485127-4e1f95bc-6cef-4df9-b7b3-1d6a86400091.png)
![Simulator Screen Shot - iPad (10th generation) - 2022-11-23 at 15 31 21](https://user-images.githubusercontent.com/72330884/203485138-0d6473f7-0a2f-4d73-907c-5802b6d8c0b2.png)


## Checklist
- [X] Is the branch you are merging on correct?
- [X] Do you comply with coding conventions?
- [X] Are there any changes not related to PR?
- [X] Has my code been self-reviewed?
