### PR TITLE
Fix/duplicated downloading/#354

### DIFF
--- a/RollingPaper/RollingPaper/ViewControllers/Core/GiftStorage/GiftStorageCollectionCell.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/GiftStorage/GiftStorageCollectionCell.swift
@@ -80,14 +80,14 @@ final class GiftStorageCollectionCell: UICollectionViewCell {
     }
     
     // 해당되는 셀 설정하기
-    func setCell(paper: PaperPreviewModel?, thumbnail: UIImage?) {
+    func setCell(paper: PaperPreviewModel?, thumbnail: UIImage?, cellWidth: CGFloat) {
         if let paper = paper {
             date.text = changeDateFormat(date: paper.endTime)
             title.text = paper.title
             sender.text = (paper.creator?.name ?? "?") + "님이 보낸 선물"
             preview.image = thumbnail
             preview.snp.updateConstraints({ make in
-                make.width.equalTo(GiftStorageLength.paperThumbnailWidth)
+                make.width.equalTo(cellWidth)
                 make.height.equalTo(GiftStorageLength.paperThumbnailHeight)
             })
             isHidden = false
@@ -116,7 +116,7 @@ extension GiftStorageCollectionCell {
         preview.snp.makeConstraints({ make in
             make.top.equalToSuperview()
             make.leading.equalToSuperview()
-            make.width.equalTo(GiftStorageLength.paperThumbnailWidth)
+            make.width.equalTo(GiftStorageLength.paperThumbnailWidth1)
             make.height.equalTo(GiftStorageLength.paperThumbnailHeight)
         })
         previewOverlay.snp.makeConstraints({ make in

--- a/RollingPaper/RollingPaper/ViewControllers/Core/GiftStorage/GiftStorageLength.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/GiftStorage/GiftStorageLength.swift
@@ -16,8 +16,9 @@ final class GiftStorageLength {
     static let sectionBottomMargin: CGFloat = 48
     static let sectionRightMargin: CGFloat = 36
     static let sectionLeftMargin: CGFloat = 36
-    static var paperThumbnailWidth: CGFloat = (UIScreen.main.bounds.width*0.75-(sectionLeftMargin+sectionRightMargin)) // 반응형
-    static let paperThumbnailHeight: CGFloat = paperThumbnailWidth*0.16
+    static let paperThumbnailWidth1: CGFloat = (UIScreen.main.bounds.width*0.75-(sectionLeftMargin+sectionRightMargin+cellHorizontalSpace+2))
+    static let paperThumbnailWidth2: CGFloat = (UIScreen.main.bounds.width*1.0-(sectionLeftMargin+sectionRightMargin+cellHorizontalSpace+2))
+    static let paperThumbnailHeight: CGFloat = paperThumbnailWidth1*0.16
     static let cellHorizontalSpace: CGFloat = 0
     static let cellVerticalSpace: CGFloat = 10
     static let labelSpacing: CGFloat = 10

--- a/RollingPaper/RollingPaper/ViewControllers/Core/GiftStorage/GiftStorageViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/GiftStorage/GiftStorageViewController.swift
@@ -17,6 +17,7 @@ final class GiftStorageViewController: UIViewController {
     private var cancellables = Set<AnyCancellable>()
     private var splitViewIsOpened: Bool = true
     private var viewIsChange: Bool = false
+    private var cellWidth: CGFloat = GiftStorageLength.paperThumbnailWidth1
     
     // 빈 화면일 때 보여주는 뷰
     private lazy var emptyView: UILabel = {
@@ -129,8 +130,7 @@ final class GiftStorageViewController: UIViewController {
     
     // 컬렉션 뷰 셀의 가로 길이 업데이트하기
     private func updateLayout() {
-        let multiplyVal = splitViewIsOpened ? 0.75 : 1.0
-        GiftStorageLength.paperThumbnailWidth = (UIScreen.main.bounds.width*multiplyVal-(GiftStorageLength.sectionLeftMargin+GiftStorageLength.sectionRightMargin+GiftStorageLength.cellHorizontalSpace+2))/2
+        cellWidth = splitViewIsOpened ? GiftStorageLength.paperThumbnailWidth1 : GiftStorageLength.paperThumbnailWidth2
         paperCollectionView.reloadData()
     }
     
@@ -186,7 +186,7 @@ final class GiftStorageViewController: UIViewController {
 extension GiftStorageViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
     // 셀의 사이즈
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return CGSize(width: GiftStorageLength.paperThumbnailWidth, height: GiftStorageLength.paperThumbnailHeight)
+        return CGSize(width: cellWidth, height: GiftStorageLength.paperThumbnailHeight)
     }
     // 위아래 셀 간격
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
@@ -210,7 +210,7 @@ extension GiftStorageViewController: UICollectionViewDelegate, UICollectionViewD
               let paper = viewModel.papersByYear[viewModel.years[indexPath.section]]?[indexPath.item]
         else {return UICollectionViewCell()}
         let thumbnail = viewModel.thumbnails[paper.paperId, default: paper.template.thumbnail]
-        cell.setCell(paper: paper, thumbnail: thumbnail)
+        cell.setCell(paper: paper, thumbnail: thumbnail, cellWidth: cellWidth)
         
         return cell
     }

--- a/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageClosedCollectionCell.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageClosedCollectionCell.swift
@@ -70,13 +70,13 @@ final class PaperStorageClosedCollectionCell: UICollectionViewCell {
     }
     
     // 해당되는 셀 설정하기
-    func setCell(paper: PaperPreviewModel?, thumbnail: UIImage?) {
+    func setCell(paper: PaperPreviewModel?, thumbnail: UIImage?, cellWidth: CGFloat) {
         if let paper = paper {
             date.text = changeDateFormat(date: paper.endTime)
             title.text = paper.title
             preview.image = thumbnail
             preview.snp.updateConstraints({ make in
-                make.width.equalTo(PaperStorageLength.closedPaperThumbnailWidth)
+                make.width.equalTo(cellWidth)
                 make.height.equalTo(PaperStorageLength.closedPaperThumbnailHeight)
             })
             isHidden = false
@@ -104,7 +104,7 @@ extension PaperStorageClosedCollectionCell {
         preview.snp.makeConstraints({ make in
             make.top.equalToSuperview()
             make.leading.equalToSuperview()
-            make.width.equalTo(PaperStorageLength.closedPaperThumbnailWidth)
+            make.width.equalTo(PaperStorageLength.closedPaperThumbnailWidth1)
             make.height.equalTo(PaperStorageLength.closedPaperThumbnailHeight)
         })
         previewOverlay.snp.makeConstraints({ make in

--- a/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageLength.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageLength.swift
@@ -17,8 +17,9 @@ final class PaperStorageLength {
     static let sectionRightMargin: CGFloat = 36
     static let sectionLeftMargin: CGFloat = 36
     
-    static var openedPaperThumbnailWidth: CGFloat = (UIScreen.main.bounds.width*0.75-(sectionLeftMargin+sectionRightMargin+openedCellHorizontalSpace+2))/2 // 반응형
-    static let openedPaperThumbnailHeight: CGFloat = openedPaperThumbnailWidth*0.33
+    static let openedPaperThumbnailWidth1: CGFloat = (UIScreen.main.bounds.width*0.75-(sectionLeftMargin+sectionRightMargin+openedCellHorizontalSpace+2))/2
+    static let openedPaperThumbnailWidth2: CGFloat = (UIScreen.main.bounds.width*1.0-(sectionLeftMargin+sectionRightMargin+openedCellHorizontalSpace+2))/2 
+    static let openedPaperThumbnailHeight: CGFloat = openedPaperThumbnailWidth1*0.33
     static let openedPaperTitleBottomMargin: CGFloat = 16
     static let openedPaperTitleRightMargin: CGFloat = 16
     static let openedPaperTitleLeftMargin: CGFloat = 16
@@ -35,8 +36,9 @@ final class PaperStorageLength {
     static let clockImageWidth: CGFloat = 14
     static let clockImageHeight: CGFloat = 14
     
-    static var closedPaperThumbnailWidth: CGFloat = (UIScreen.main.bounds.width*0.75-(sectionLeftMargin+sectionRightMargin+2)) // 반응형
-    static let closedPaperThumbnailHeight: CGFloat = closedPaperThumbnailWidth*0.16
+    static let closedPaperThumbnailWidth1: CGFloat = (UIScreen.main.bounds.width*0.75-(sectionLeftMargin+sectionRightMargin+2))
+    static let closedPaperThumbnailWidth2: CGFloat = (UIScreen.main.bounds.width*1.0-(sectionLeftMargin+sectionRightMargin+2))
+    static let closedPaperThumbnailHeight: CGFloat = closedPaperThumbnailWidth1*0.16
     static let closedCellHorizontalSpace: CGFloat = 0
     static let closedCellVerticalSpace: CGFloat = 10
     static let labelSpacing: CGFloat = 10

--- a/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageOpenedCollectionCell.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageOpenedCollectionCell.swift
@@ -52,12 +52,12 @@ final class PaperStorageOpenedCollectionCell: UICollectionViewCell {
     }
     
     // 해당되는 셀 설정하기
-    func setCell(paper: PaperPreviewModel, thumbnail: UIImage?, now: Date) {
+    func setCell(paper: PaperPreviewModel, thumbnail: UIImage?, now: Date, cellWidth: CGFloat) {
         timer.setEndTime(time: paper.endTime)
         title.text = paper.title
         preview.image = thumbnail
         preview.snp.updateConstraints({ make in
-            make.width.equalTo(PaperStorageLength.openedPaperThumbnailWidth)
+            make.width.equalTo(cellWidth)
             make.height.equalTo(PaperStorageLength.openedPaperThumbnailHeight)
         })
     }
@@ -80,7 +80,7 @@ extension PaperStorageOpenedCollectionCell {
         preview.snp.makeConstraints({ make in
             make.top.equalToSuperview()
             make.leading.equalToSuperview()
-            make.width.equalTo(PaperStorageLength.openedPaperThumbnailWidth)
+            make.width.equalTo(PaperStorageLength.openedPaperThumbnailWidth1)
             make.height.equalTo(PaperStorageLength.openedPaperThumbnailHeight)
         })
         previewOverlay.snp.makeConstraints({ make in

--- a/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageViewController.swift
+++ b/RollingPaper/RollingPaper/ViewControllers/Core/PaperStorage/PaperStorageViewController.swift
@@ -20,6 +20,8 @@ final class PaperStorageViewController: UIViewController {
     private var dataState: DataState = .nothing
     private var isContextChosen: Bool = false
     private var isContextRepeated = false
+    private var openedCellWidth = PaperStorageLength.openedPaperThumbnailWidth1
+    private var closedCellWidth = PaperStorageLength.closedPaperThumbnailWidth1
     
     lazy private var titleEmbedingTextField: UITextField = UITextField()
     
@@ -159,9 +161,8 @@ final class PaperStorageViewController: UIViewController {
     
     // 컬렉션 뷰 셀의 가로 길이 업데이트하기
     private func updateLayout() {
-        let multiplyVal = splitViewIsOpened ? 0.75 : 1.0
-        PaperStorageLength.openedPaperThumbnailWidth = (UIScreen.main.bounds.width*multiplyVal-(PaperStorageLength.sectionLeftMargin+PaperStorageLength.sectionRightMargin+PaperStorageLength.openedCellHorizontalSpace+2))/2
-        PaperStorageLength.closedPaperThumbnailWidth = (UIScreen.main.bounds.width*multiplyVal-(PaperStorageLength.sectionLeftMargin+PaperStorageLength.sectionRightMargin))
+        openedCellWidth = splitViewIsOpened ? PaperStorageLength.openedPaperThumbnailWidth1 : PaperStorageLength.openedPaperThumbnailWidth2
+        closedCellWidth = splitViewIsOpened ? PaperStorageLength.closedPaperThumbnailWidth1 : PaperStorageLength.closedPaperThumbnailWidth2
         
         UIView.performWithoutAnimation({ [weak self] in
             guard let self = self else {return}
@@ -222,7 +223,7 @@ final class PaperStorageViewController: UIViewController {
 extension PaperStorageViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
     // 셀의 사이즈
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return indexPath.section == 0 ? CGSize(width: PaperStorageLength.openedPaperThumbnailWidth, height: PaperStorageLength.openedPaperThumbnailHeight) : CGSize(width: PaperStorageLength.closedPaperThumbnailWidth, height: PaperStorageLength.closedPaperThumbnailHeight)
+        return indexPath.section == 0 ? CGSize(width: openedCellWidth, height: PaperStorageLength.openedPaperThumbnailHeight) : CGSize(width: closedCellWidth, height: PaperStorageLength.closedPaperThumbnailHeight)
     }
     // 위아래 셀 간격
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
@@ -254,16 +255,16 @@ extension PaperStorageViewController: UICollectionViewDelegate, UICollectionView
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PaperStorageOpenedCollectionCell.identifier, for: indexPath) as? PaperStorageOpenedCollectionCell else {return UICollectionViewCell()}
             let paper = viewModel.openedPapers[indexPath.item]
             let thumbnail = viewModel.thumbnails[paper.paperId, default: paper.template.thumbnail]
-            cell.setCell(paper: paper, thumbnail: thumbnail, now: viewModel.currentTime)
+            cell.setCell(paper: paper, thumbnail: thumbnail, now: viewModel.currentTime, cellWidth: openedCellWidth)
             return cell
         } else {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PaperStorageClosedCollectionCell.identifier, for: indexPath) as? PaperStorageClosedCollectionCell else {return UICollectionViewCell()}
             if dataState == .onlyOpened {
-                cell.setCell(paper: nil, thumbnail: nil)
+                cell.setCell(paper: nil, thumbnail: nil, cellWidth: 0)
             } else {
                 let paper = viewModel.closedPapers[indexPath.item]
                 let thumbnail = viewModel.thumbnails[paper.paperId, default: paper.template.thumbnail]
-                cell.setCell(paper: paper, thumbnail: thumbnail)
+                cell.setCell(paper: paper, thumbnail: thumbnail, cellWidth: closedCellWidth)
             }
             return cell
         }

--- a/RollingPaper/RollingPaper/ViewModels/Core/GiftStorage/GiftStorageViewModel.swift
+++ b/RollingPaper/RollingPaper/ViewModels/Core/GiftStorage/GiftStorageViewModel.swift
@@ -79,6 +79,7 @@ class GiftStorageViewModel {
     private func downloadLocalThumbnails(outputValue: Output) {
         var downloadCount = 0
         for paper in papersFromLocal {
+            if thumbnails[paper.paperId] != nil { continue }
             if let thumbnailURLString = paper.thumbnailURLString {
                 if let cachedImage = NSCacheManager.shared.getImage(name: thumbnailURLString) {
                     // 진입 경로1 - 캐시 데이터를 통한 다운로드
@@ -137,6 +138,7 @@ class GiftStorageViewModel {
     private func downloadServerThumbnails(outputValue: Output) {
         var downloadCount = 0
         for paper in papersFromServer {
+            if thumbnails[paper.paperId] != nil { continue }
             if let thumbnailURLString = paper.thumbnailURLString {
                 if let cachedImage = NSCacheManager.shared.getImage(name: thumbnailURLString) {
                     // 진입 경로1 - 캐시 데이터를 통한 다운로드

--- a/RollingPaper/RollingPaper/ViewModels/Core/PaperStorage/PaperStorageViewModel.swift
+++ b/RollingPaper/RollingPaper/ViewModels/Core/PaperStorage/PaperStorageViewModel.swift
@@ -152,6 +152,7 @@ class PaperStorageViewModel {
     private func downloadLocalThumbnails(outputValue: Output) {
         var downloadCount = 0
         for paper in papersFromLocal {
+            if thumbnails[paper.paperId] != nil { continue }
             if let thumbnailURLString = paper.thumbnailURLString {
                 if let cachedImage = NSCacheManager.shared.getImage(name: thumbnailURLString) {
                     // 진입 경로1 - 캐시 데이터를 통한 다운로드
@@ -210,6 +211,7 @@ class PaperStorageViewModel {
     private func downloadServerThumbnails(outputValue: Output) {
         var downloadCount = 0
         for paper in papersFromServer {
+            if thumbnails[paper.paperId] != nil { continue }
             if let thumbnailURLString = paper.thumbnailURLString {
                 if let cachedImage = NSCacheManager.shared.getImage(name: thumbnailURLString) {
                     // 진입 경로1 - 캐시 데이터를 통한 다운로드


### PR DESCRIPTION
# Issue Number
🔒 Close #354
🔒 Close #355

## New features
- 페이퍼 보관함 및 선물함에서 다운 받았던 썸네일이 중복해서 다시 다운로드 되는 것을 막았습니다.
- 컬렉션 뷰의 셀의 길이를 쉽게 조절할 수 있도록 Length 파일을 완전히 분리시켰습니다. (Length 파일의 숫자만 건들이면 쉽게 길이 변경 가능)

## Checklist
- [X] Is the branch you are merging on correct?
- [X] Do you comply with coding conventions?
- [X] Are there any changes not related to PR?
- [X] Has my code been self-reviewed?
