### PR TITLE
Feature/Add NSPhotoLibraryAddUsageDescription/#375 

### DIFF
--- a/RollingPaper/RollingPaper.xcodeproj/project.pbxproj
+++ b/RollingPaper/RollingPaper.xcodeproj/project.pbxproj
@@ -1043,6 +1043,7 @@
 				INFOPLIST_FILE = RollingPaper/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "네모네모";
 				INFOPLIST_KEY_NSCameraUsageDescription = "프로필 사진 첨부, 카드작성 사진 첨부 기능 사용을 위해 사진 라이브러리 접근권한 동의가 필요합니다. 설정에서 이를 변경할 수 있습니다.";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "작성된 카드 이미지를 기기의 사진 라이브러리에 저장하기 위하여 사진 라이브러리 접근권한 동의가 필요합니다. 설정에서 이를 변경할 수 있습니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIRequiresFullScreen = YES;
@@ -1084,6 +1085,7 @@
 				INFOPLIST_FILE = RollingPaper/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "네모네모";
 				INFOPLIST_KEY_NSCameraUsageDescription = "프로필 사진 첨부, 카드작성 사진 첨부 기능 사용을 위해 사진 라이브러리 접근권한 동의가 필요합니다. 설정에서 이를 변경할 수 있습니다.";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "작성된 카드 이미지를 기기의 사진 라이브러리에 저장하기 위하여 사진 라이브러리 접근권한 동의가 필요합니다. 설정에서 이를 변경할 수 있습니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIRequiresFullScreen = YES;


### PR DESCRIPTION
# Issue Number
🔒 Close #375

## New features

- info.list 파일에 NSPhotoLibraryAddUsageDescription을 추가
- 만들어진 카드를 꾹눌러서 사진첩에 저장하려고 할때, 라이브러리 접근권한이 뜸.

- screenshot(optional)
![simulator_screenshot_E3C4FE6E-F402-49E0-932C-B9A7F999CBF4](https://user-images.githubusercontent.com/40324511/204711435-f014ba54-6d36-49d1-bc7c-eba59f3dab67.png)

## Review points

- write here

## Questions

- write here

## References

- write here 

## Checklist

- [ ] Is the branch you are merging on correct?
- [ ] Do you comply with coding conventions?
- [ ] Are there any changes not related to PR?
- [ ] Has my code been self-reviewed?
